### PR TITLE
Add SeatGeek schedule data

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package serves two purposes:
 
 ## Suggested Setup
 
-There is no additional configuration if you simply wish to get the latest playoff odds.
+There is no additional configuration if you simply wish to get the latest playoff odds and next game.
 
 To set up the hue integration, you can either:
 
@@ -48,7 +48,7 @@ See full instructions [here](https://github.com/github/hubot/blob/master/docs/sc
 
 ## Commands
 
-- `hubot predators` - Show your team's current playoff odds
+- `hubot predators` - Show your team's current playoff odds and next game
 - `hubot predators goal` - Run the light show in your team's colors
 - `hubot predators colors` - Set the Hue lights to your team's colors
 - `hubot predators twitter` - Get the latest news from your team on Twitter

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "htmlparser": "^1.7.7",
     "moment": "^2.10.3",
     "node-hue-api": "^1.0.5",
+    "seatgeek": "^0.3.8",
     "soupselect": "^0.2.0",
     "twitter": "^1.2.5",
     "underscore": "^1.8.3",


### PR DESCRIPTION
Fixes #3 

When asking the bot for a particular team, you will now get the next scheduled game (if any) based on data from [SeatGeek](http://platform.seatgeek.com).
