### PR TITLE
Fix HTTPS in SeatGeek module

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "htmlparser": "^1.7.7",
     "moment": "^2.10.3",
     "node-hue-api": "^1.0.5",
-    "seatgeek": "^0.3.8",
+    "seatgeek": "stephenyeargin/seatgeek.js#fix-https",
     "soupselect": "^0.2.0",
     "twitter": "^1.2.5",
     "underscore": "^1.8.3",


### PR DESCRIPTION
The maintainer of `seatgeek` hasn't yet merged the fixed version of the module that properly points the resources to their SSL counterparts. This makes the package rely on my branch instead that has the fix.
