### PR TITLE
Fix SeatGeek integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: node_js
 node_js:
+  - "node"
+  - "6"
+  - "5"
+  - "4"
   - "0.12"
-  - "0.10"
   - "iojs"
 sudo: false
 cache:

--- a/README.md
+++ b/README.md
@@ -9,31 +9,45 @@ This package serves two purposes:
 
 ## Suggested Setup
 
-There is no additional configuration if you simply wish to get the latest playoff odds and next game.
+There is no additional configuration if you simply wish to get the latest playoff odds.
+
+### SeatGeek (Next Game)
+
+1. Register for a SeatGeek developer account.
+2. Create an application
+3. Set the `Client ID` as `HUBOT_SEATGEEK_CLIENT_ID`
+
+```
+export HUBOT_SEATGEEK_CLIENT_ID=xxxxxxxxxxxxxxx
+```
+
+### Hue
 
 To set up the hue integration, you can either:
 
-1. Install the [hubot-philipshue](https://github.com/kingbin/hubot-philipshue) package using their instructions for getting a username hash.
-2. Run the command below to obtain the necessary hash value.
+- Install the [hubot-philipshue](https://github.com/kingbin/hubot-philipshue) package using their instructions for getting a username hash.
+- Run the command below to obtain the necessary hash value.
 
 ```
-curl -v -H "Content-Type: application/json" -X POST 'http://YourHueHub/api' -d '{"username": "YourHash", "devicetype": "YourAppName"}'
+curl -v -H "Content-Type: application/json" -X POST 'http://YourHueHubIPAddress/api' -d '{"username": "YourHash", "devicetype": "YourAppName"}'
 ```
 
 The two configuration values to add match the above scripts, so they can be shared.
 
 ```
-export PHILIPS_HUE_HASH="secrets"
+export PHILIPS_HUE_HASH="xxxxxxxxxx"
 export PHILIPS_HUE_IP="xxx.xxx.xxx.xxx"
 ```
+
+### Twitter
 
 You can also set the Twitter credentials (if not already set for another plugin) to get the latest team news.
 
 ```
-export HUBOT_TWITTER_CONSUMER_KEY="secret stuff"
-export HUBOT_TWITTER_CONSUMER_SECRET="secret stuff"
-export HUBOT_TWITTER_ACCESS_TOKEN="secret stuff"
-export HUBOT_TWITTER_ACCESS_TOKEN_SECRET="secret stuff"
+export HUBOT_TWITTER_CONSUMER_KEY="xxxxxxxxxxxx"
+export HUBOT_TWITTER_CONSUMER_SECRET="xxxxxxxxxxxx"
+export HUBOT_TWITTER_ACCESS_TOKEN="xxxxxxxxxxxx"
+export HUBOT_TWITTER_ACCESS_TOKEN_SECRET="xxxxxxxxxxxx"
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -19,27 +19,27 @@
   },
   "dependencies": {
     "htmlparser": "^1.7.7",
-    "moment": "^2.10.3",
-    "node-hue-api": "^1.0.5",
-    "seatgeek": "stephenyeargin/seatgeek.js#fix-https",
+    "moment": "^2.18.1",
+    "node-hue-api": "^2.4.2",
+    "seatgeek-client": "^0.1.5",
     "soupselect": "^0.2.0",
-    "twitter": "^1.2.5",
+    "twitter": "^1.7.0",
     "underscore": "^1.8.3",
-    "underscore.string": "^3.0.3"
+    "underscore.string": "^3.3.4"
   },
   "devDependencies": {
-    "chai": "^2.1.1",
-    "coffee-script": "1.6.3",
-    "grunt": "^0.4.5",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-mocha-test": "~0.12.7",
-    "grunt-release": "~0.11.0",
+    "chai": "^3.5.0",
+    "coffee-script": "1.12.6",
+    "grunt": "^1.0.1",
+    "grunt-cli": "^1.2.0",
+    "grunt-contrib-watch": "~1.0.0",
+    "grunt-mocha-test": "~0.13.2",
+    "grunt-release": "~0.14.0",
     "hubot": "2.x",
-    "matchdep": "~0.3.0",
-    "mocha": "^2.1.0",
-    "sinon": "^1.13.0",
-    "sinon-chai": "^2.7.0"
+    "matchdep": "~1.0.1",
+    "mocha": "^3.4.1",
+    "sinon": "^2.2.0",
+    "sinon-chai": "^2.10.0"
   },
   "main": "index.coffee",
   "scripts": {

--- a/src/hubot-hockey.coffee
+++ b/src/hubot-hockey.coffee
@@ -2,23 +2,23 @@
 #   Get the latest hockey playoff odds and light the lamp
 #
 # Dependencies:
-#   "coffee-script": "~1.6"
 #   "htmlparser": "^1.7.7"
-#   "node-hue-api": "^1.0.5"
+#   "moment": "^2.18.1"
+#   "node-hue-api": "^2.4.2"
+#   "seatgeek-client": "^0.1.5"
 #   "soupselect": "^0.2.0"
+#   "twitter": "^1.7.0"
 #   "underscore": "^1.8.3"
-#   "underscore.string": "^3.0.3"
-#   "moment": "^2.10.3"
-#   "twitter": "^1.2.5"
-#   "seatgeek": "^0.3.8"
+#   "underscore.string": "^3.3.4"
 #
 # Configuration:
-#   PHILIPS_HUE_HASH - Optional; Secret hash value representing a Hubot account on the hue bridge
+#   PHILIPS_HUE_HASH - Optional; Token for a Hubot account on the hue bridge
 #   PHILIPS_HUE_IP - Optional; IP address or hostname of your bridge
 #   HUBOT_TWITTER_CONSUMER_KEY - Optional; Twitter consumer key
 #   HUBOT_TWITTER_CONSUMER_SECRET - Optional; Twitter consumer secret
 #   HUBOT_TWITTER_ACCESS_TOKEN - Optional; Twitter access token
 #   HUBOT_TWITTER_ACCESS_TOKEN_SECRET - Optional; Twitter access token secret
+#   HUBOT_SEATGEEK_CLIENT_ID - Optional; Authorization token for SeatGeek
 #
 # Commands:
 #   hubot <team or city> - Get the lastest playoff odds and result from SportsClubStats and schedule from SeatGeek
@@ -29,312 +29,7 @@
 # Author:
 #   stephenyeargin
 
-hockey_teams = [
-  {
-    name: 'Anaheim Ducks',
-    regex: '(anaheim ducks|anaheim|ducks|ana)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Pacific/Anaheim.html',
-    twitter_handle: 'AnaheimDucks',
-    colors: [
-      {hue: 13, saturation: 78, brightness: 94},
-      {hue: 0, saturation: 2, brightness: 24},
-      {hue: 150, saturation: 2, brightness: 70}
-    ]
-  },
-  {
-    name: 'Boston Bruins',
-    regex: '(boston bruins|boston|bruins|bos)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Boston.html',
-    twitter_handle: 'NHLBruins',
-    colors: [
-      {hue: 0, saturation: 2, brightness: 24},
-      {hue: 35, saturation: 76, brightness: 98},
-      {hue: 60, saturation: 1, brightness: 92}
-    ]
-  },
-  {
-    name: 'Buffalo Sabres',
-    regex: '(buffalo sabres|bufalo|sabres|buf)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Buffalo.html',
-    twitter_handle: 'BuffaloSabres',
-    colors: [
-      {hue: 213, saturation: 42, brightness: 42},
-      {hue: 35, saturation: 76, brightness: 98},
-      {hue: 150, saturation: 2, brightness: 70}
-    ]
-  },
-  {
-    name: 'Calgary Flames',
-    regex: '(calgary flames|calgary|flames|cal)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Pacific/Calgary.html',
-    twitter_handle: 'NHLFlames',
-    colors: [
-      {hue: 0, saturation: 2, brightness: 24},
-      {hue: 37, saturation: 63, brightness: 99}
-    ]
-  },
-  {
-    name: 'Carolina Hurricanes',
-    regex: '(carolina hurricanes|carolina|hurricanes|car|canes)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Carolina.html',
-    twitter_handle: 'NHLCanes',
-    colors: [
-      {hue: 0, saturation: 2, brightness: 24},
-      {hue: 1, saturation: 69, brightness: 76}
-    ]
-  },
-  {
-    name: 'Chicago Blackhawks',
-    regex: '(chicago blackhawks|chicago|blackhawks|chi|hawks)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Central/Chicago.html',
-    twitter_handle: 'NHLBlackhawks',
-    colors: [
-      {hue: 255, saturation: 59, brightness: 52},
-      {hue: 35, saturation: 75, brightness: 80}
-    ]
-  },
-  {
-    name: 'Colorado Avalanche',
-    regex: '(colorado avalanche|colorado|avalanche|col|avs|denver)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Central/Colorado.html',
-    twitter_handle: 'Avalanche',
-    colors: [
-      {hue: 348, saturation: 53, brightness: 48},
-      {hue: 0, saturation: 1, brightness: 23}
-    ]
-  },
-  {
-    name: 'Columbus Blue Jackets',
-    regex: '(columbus blue jackets|columbus|blue jackets|cbj|bluejackets)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Columbus.html',
-    twitter_handle: 'BlueJacketsNHL',
-    colors: [
-      {hue: 213, saturation: 42, brightness: 42},
-      {hue: 1, saturation: 69, brightness: 76}
-    ]
-  },
-  {
-    name: 'Dallas Stars',
-    regex: '(dallas stars|dallas|stars|dal)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Central/Dallas.html',
-    twitter_handle: 'DallasStars',
-    colors: [
-      {hue: 0, saturation: 2, brightness: 24},
-      {hue: 154, saturation: 54, brightness: 43}
-    ]
-  },
-  {
-    name: 'Detroit Red Wings',
-    regex: '(detroit red wings|detroit|red wings|det|redwings|wings)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Detroit.html',
-    twitter_handle: 'DetroitRedWings',
-    colors: [
-      {hue: 1, saturation: 69, brightness: 76},
-      {hue: 60, saturation: 1, brightness: 92}
-    ]
-  },
-  {
-    name: 'Edmonton Oilers',
-    regex: '(edmonton oilers|edmonton|oilers|edm|oil)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Pacific/Edmonton.html',
-    twitter_handle: 'EdmontonOilers',
-    colors: [
-      {hue: 210, saturation: 61, brightness: 47},
-      {hue: 15, saturation: 74, brightness: 81}
-    ]
-  },
-  {
-    name: 'Florida Panthers',
-    regex: '(florida panthers|florida|panthers|fla|cats)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Florida.html',
-    twitter_handle: 'FlaPanthers',
-    colors: [
-      {hue: 39, saturation: 82, brightness: 77},
-      {hue: 35, saturation: 76, brightness: 98}
-    ]
-  },
-  {
-    name: 'Los Angeles Kings',
-    regex: '(los angeles kings|los angeles|kings|lak|losangeles)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Pacific/LosAngeles.html',
-    twitter_handle: 'LAKings',
-    colors: [
-      {hue: 0, saturation: 2, brightness: 24},
-      {hue: 228, saturation: 45, brightness: 44}
-    ]
-  },
-  {
-    name: 'Minnesota Wild',
-    regex: '(minnesota wild|minnesota|wild|min)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Central/Minnesota.html',
-    twitter_handle: 'mnwild',
-    colors: [
-      {hue: 36, saturation: 20, brightness: 88},
-      {hue: 153, saturation: 49, brightness: 36}
-    ]
-  },
-  {
-    name: 'Montreal Canadiens',
-    regex: '(montreal canadiens|montreal|canadiens|mtl|habs)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Montreal.html',
-    twitter_handle: 'CanadiensMTL',
-    colors: [
-      {hue: 355, saturation: 62, brightness: 64},
-      {hue: 218, saturation: 58, brightness: 47}
-    ]
-  },
-  {
-    name: 'Nashville Predators',
-    regex: '(nashville predators|nashville|predators|nas|preds)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Central/Nashville.html',
-    twitter_handle: 'predsnhl',
-    colors: [
-      {hue: 35, saturation: 76, brightness: 98},
-      {hue: 60, saturation: 1, brightness: 92},
-      {hue: 213, saturation: 42, brightness: 42}
-    ]
-  },
-  {
-    name: 'New Jersey Devils',
-    regex: '(new jersey devils|new jersey|devils|njd)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/NewJersey.html',
-    twitter_handle: 'NHLDevils',
-    colors: [
-      {hue: 1, saturation: 69, brightness: 76},
-      {hue: 0, saturation: 2, brightness: 24}
-    ]
-  },
-  {
-    name: 'New York Islanders',
-    regex: '(new york islanders|islanders|nyi|isles)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/NYIslanders.html',
-    twitter_handle: 'NYIslanders',
-    colors: [
-      {hue: 210, saturation: 70, brightness: 49},
-      {hue: 13, saturation: 79, brightness: 94}
-    ]
-  },
-  {
-    name: 'New York Rangers',
-    regex: '(new york rangers|rangers|nyr|blue shirts|blueshirts)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/NYRangers.html',
-    twitter_handle: 'NYRangers',
-    colors: [
-      {hue: 1, saturation: 69, brightness: 76},
-      {hue: 213, saturation: 42, brightness: 42}
-    ]
-  },
-  {
-    name: 'Ottawa Senators',
-    regex: '(ottawa senators|ottawa|senators|ott|sens)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Ottawa.html',
-    twitter_handle: 'Senators',
-    colors: [
-      {hue: 1, saturation: 69, brightness: 76},
-      {hue: 39, saturation: 82, brightness: 77}
-    ]
-  },
-  {
-    name: 'Philidelphia Flyers',
-    regex: '(philidelphia flyers|philidelphia|flyers|phi)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Philadelphia.html',
-    twitter_handle: 'NHLFlyers',
-    colors: [
-      {hue: 0, saturation: 2, brightness: 24},
-      {hue: 13, saturation: 78, brightness: 94}
-    ]
-  },
-  {
-    name: 'Arizona Coyotes',
-    regex: '(arizona coyotes|arizona|coyotes|ari|phoenix coyotes|phoenix|phx|yotes)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Pacific/Arizona.html',
-    twitter_handle: 'ArizonaCoyotes',
-    colors: [
-      {hue: 0, saturation: 2, brightness: 24},
-      {hue: 359, saturation: 50, brightness: 53}
-    ]
-  },
-  {
-    name: 'Pittsburgh Penguins',
-    regex: '(pittsburgh penguins|pittsburgh|penguins|pit|pitt)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Pittsburgh.html',
-    twitter_handle: 'penguins',
-    colors: [
-      {hue: 35, saturation: 42, brightness: 72},
-      {hue: 0, saturation: 2, brightness: 24}
-    ]
-  },
-  {
-    name: 'San Jose Sharks',
-    regex: '(san jose sharks|san jose|sharks|sjs|sanjose)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Pacific/SanJose.html',
-    twitter_handle: 'SanJoseSharks',
-    colors: [
-      {hue: 184, saturation: 100, brightness: 46},
-      {hue: 0, saturation: 2, brightness: 24}
-    ]
-  },
-  {
-    name: 'Tampa Bay Lightning',
-    regex: '(tampa bay lightning|tampa bay|lightning|tbl|tampabay)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Atlantic/TampaBay.html',
-    twitter_handle: 'TBLightning',
-    colors: [
-      {hue: 60, saturation: 1, brightness: 92},
-      {hue: 210, saturation: 61, brightness: 47}
-    ]
-  },
-  {
-    name: 'St. Louis Blues',
-    regex: '(st\. louis blues|st\. louis|blues|stl|stlouis|saint louis|st louis|blue notes)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Central/StLouis.html',
-    twitter_handle: 'StLouisBlues',
-    colors: [
-      {hue: 35, saturation: 76, brightness: 98},
-      {hue: 213, saturation: 42, brightness: 42}
-    ]
-  },
-  {
-    name: 'Toronto Maple Leafs',
-    regex: '(toronto maple leafs|toronto|maple leafs|tor|leafs|mapleleafs)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Toronto.html',
-    twitter_handle: 'MapleLeafs',
-    colors: [
-      {hue: 60, saturation: 1, brightness: 92},
-      {hue: 210, saturation: 61, brightness: 47}
-    ]
-  },
-  {
-    name: 'Vancouver Canucks',
-    regex: '(vancouver canucks|vancouver|canucks|van|nucks)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Pacific/Vancouver.html',
-    twitter_handle: 'VanCanucks',
-    colors: [
-      {hue: 223, saturation: 18, brightness: 31},
-      {hue: 60, saturation: 1, brightness: 64}
-    ]
-  },
-  {
-    name: 'Washington Capitals',
-    regex: '(washington capitals|washington|capitals|wsh|caps)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Washington.html',
-    twitter_handle: 'washcaps',
-    colors: [
-      {hue: 1, saturation: 69, brightness: 76},
-      {hue: 213, saturation: 42, brightness: 42}
-    ]
-  },
-  {
-    name: 'Winnipeg Jets',
-    regex: '(winnipeg jets|winnipeg|jets|wpg|peg)',
-    scs_url: 'http://www.sportsclubstats.com/NHL/Western/Central/Winnipeg.html',
-    twitter_handle: 'NHLJets',
-    colors: [
-      {hue: 199, saturation: 100, brightness: 57},
-      {hue: 213, saturation: 42, brightness: 42}
-    ]
-  },
-]
+hockey_teams = require './teams.json'
 
 # Moment
 moment = require("moment")
@@ -346,7 +41,8 @@ Select = require("soupselect").select
 HTMLParser = require("htmlparser")
 
 # seatgeek
-seatgeek = require('seatgeek')
+SeatGeek = require 'seatgeek-client'
+seatgeek = new SeatGeek.SeatGeekClient(process.env.HUBOT_SEATGEEK_CLIENT_ID)
 
 # Philips Hue integration
 hue = require("node-hue-api")
@@ -384,31 +80,44 @@ module.exports = (robot) ->
       showLatestTweet(team, msg)
 
   getSeatGeekData = (team, msg) ->
+    return unless process.env.HUBOT_SEATGEEK_CLIENT_ID
     robot.logger.debug team
     team_name = (team.name).toLowerCase().replace(/\s/, '-')
     robot.logger.debug team_name
-    seatgeek.events { 'performers.slug': team_name }, (err, apiresponse) ->
-      if err
-        robot.logger.error err
-        msg.send '(An error ocurred retrieving next game)'
+    events = seatgeek.getEvents({
+      'performers': [
+        field: SeatGeek.PerformerField.SLUG,
+        specificity: SeatGeek.PerformerSpecificity.ANY,
+        value: team_name
+      ],
+      'sort': {
+        option: SeatGeek.SortOption.DATETIME_LOCAL,
+        direction: SeatGeek.SortDirection.ASCENDING
+      }
+    })
+    .then (apiresponse) ->
+      robot.logger.debug apiresponse
       if apiresponse['events'].length > 0
         nextEvent = apiresponse['events'][0]
         datetime = moment(nextEvent.datetime_local).format('LLL')
         robot.logger.debug nextEvent
-        msg.send "Next Game: #{nextEvent.title} - #{datetime}"
+        msg.send "Next Game: #{nextEvent.title} - #{datetime} (local time)"
+    .catch (error) ->
+      robot.logger.error err
+      msg.send '(An error ocurred retrieving next game)'
 
   getSCSData = (team, msg) ->
     robot.logger.debug team
-    if moment().month() in [5, 6, 7, 8]
-      msg.send "It is the off-season until October. :-("
+    if moment().month() in [4, 5, 6, 7, 8]
+      msg.send "The regular season has ended."
       if process.env.HUBOT_TWITTER_CONSUMER_KEY
         msg.send "Use `#{robot.name} #{team.name} twitter` to get the latest news."
+      return
 
     msg.http(team.scs_url)
       .get() (err,res,body) ->
         # Catch errors
-        if res.statusCode != 200
-          msg.send "Got a HTTP/" + res.statusCode
+        if err || res.statusCode != 200
           msg.send "Cannot get your standings right now."
         else
 

--- a/src/teams.json
+++ b/src/teams.json
@@ -1,0 +1,562 @@
+[
+   {
+      "name": "Anaheim Ducks",
+      "regex": "(anaheim ducks|anaheim|ducks|ana)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Pacific/Anaheim.html",
+      "twitter_handle": "AnaheimDucks",
+      "colors": [
+         {
+            "hue": 13,
+            "saturation": 78,
+            "brightness": 94
+         },
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         },
+         {
+            "hue": 150,
+            "saturation": 2,
+            "brightness": 70
+         }
+      ]
+   },
+   {
+      "name": "Boston Bruins",
+      "regex": "(boston bruins|boston|bruins|bos)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Boston.html",
+      "twitter_handle": "NHLBruins",
+      "colors": [
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         },
+         {
+            "hue": 35,
+            "saturation": 76,
+            "brightness": 98
+         },
+         {
+            "hue": 60,
+            "saturation": 1,
+            "brightness": 92
+         }
+      ]
+   },
+   {
+      "name": "Buffalo Sabres",
+      "regex": "(buffalo sabres|bufalo|sabres|buf)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Buffalo.html",
+      "twitter_handle": "BuffaloSabres",
+      "colors": [
+         {
+            "hue": 213,
+            "saturation": 42,
+            "brightness": 42
+         },
+         {
+            "hue": 35,
+            "saturation": 76,
+            "brightness": 98
+         },
+         {
+            "hue": 150,
+            "saturation": 2,
+            "brightness": 70
+         }
+      ]
+   },
+   {
+      "name": "Calgary Flames",
+      "regex": "(calgary flames|calgary|flames|cal)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Pacific/Calgary.html",
+      "twitter_handle": "NHLFlames",
+      "colors": [
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         },
+         {
+            "hue": 37,
+            "saturation": 63,
+            "brightness": 99
+         }
+      ]
+   },
+   {
+      "name": "Carolina Hurricanes",
+      "regex": "(carolina hurricanes|carolina|hurricanes|car|canes)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Carolina.html",
+      "twitter_handle": "NHLCanes",
+      "colors": [
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         },
+         {
+            "hue": 1,
+            "saturation": 69,
+            "brightness": 76
+         }
+      ]
+   },
+   {
+      "name": "Chicago Blackhawks",
+      "regex": "(chicago blackhawks|chicago|blackhawks|chi|hawks)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Central/Chicago.html",
+      "twitter_handle": "NHLBlackhawks",
+      "colors": [
+         {
+            "hue": 255,
+            "saturation": 59,
+            "brightness": 52
+         },
+         {
+            "hue": 35,
+            "saturation": 75,
+            "brightness": 80
+         }
+      ]
+   },
+   {
+      "name": "Colorado Avalanche",
+      "regex": "(colorado avalanche|colorado|avalanche|col|avs|denver)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Central/Colorado.html",
+      "twitter_handle": "Avalanche",
+      "colors": [
+         {
+            "hue": 348,
+            "saturation": 53,
+            "brightness": 48
+         },
+         {
+            "hue": 0,
+            "saturation": 1,
+            "brightness": 23
+         }
+      ]
+   },
+   {
+      "name": "Columbus Blue Jackets",
+      "regex": "(columbus blue jackets|columbus|blue jackets|cbj|bluejackets)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Columbus.html",
+      "twitter_handle": "BlueJacketsNHL",
+      "colors": [
+         {
+            "hue": 213,
+            "saturation": 42,
+            "brightness": 42
+         },
+         {
+            "hue": 1,
+            "saturation": 69,
+            "brightness": 76
+         }
+      ]
+   },
+   {
+      "name": "Dallas Stars",
+      "regex": "(dallas stars|dallas|stars|dal)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Central/Dallas.html",
+      "twitter_handle": "DallasStars",
+      "colors": [
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         },
+         {
+            "hue": 154,
+            "saturation": 54,
+            "brightness": 43
+         }
+      ]
+   },
+   {
+      "name": "Detroit Red Wings",
+      "regex": "(detroit red wings|detroit|red wings|det|redwings|wings)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Detroit.html",
+      "twitter_handle": "DetroitRedWings",
+      "colors": [
+         {
+            "hue": 1,
+            "saturation": 69,
+            "brightness": 76
+         },
+         {
+            "hue": 60,
+            "saturation": 1,
+            "brightness": 92
+         }
+      ]
+   },
+   {
+      "name": "Edmonton Oilers",
+      "regex": "(edmonton oilers|edmonton|oilers|edm|oil)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Pacific/Edmonton.html",
+      "twitter_handle": "EdmontonOilers",
+      "colors": [
+         {
+            "hue": 210,
+            "saturation": 61,
+            "brightness": 47
+         },
+         {
+            "hue": 15,
+            "saturation": 74,
+            "brightness": 81
+         }
+      ]
+   },
+   {
+      "name": "Florida Panthers",
+      "regex": "(florida panthers|florida|panthers|fla|cats)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Florida.html",
+      "twitter_handle": "FlaPanthers",
+      "colors": [
+         {
+            "hue": 39,
+            "saturation": 82,
+            "brightness": 77
+         },
+         {
+            "hue": 35,
+            "saturation": 76,
+            "brightness": 98
+         }
+      ]
+   },
+   {
+      "name": "Los Angeles Kings",
+      "regex": "(los angeles kings|los angeles|kings|lak|losangeles)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Pacific/LosAngeles.html",
+      "twitter_handle": "LAKings",
+      "colors": [
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         },
+         {
+            "hue": 228,
+            "saturation": 45,
+            "brightness": 44
+         }
+      ]
+   },
+   {
+      "name": "Minnesota Wild",
+      "regex": "(minnesota wild|minnesota|wild|min)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Central/Minnesota.html",
+      "twitter_handle": "mnwild",
+      "colors": [
+         {
+            "hue": 36,
+            "saturation": 20,
+            "brightness": 88
+         },
+         {
+            "hue": 153,
+            "saturation": 49,
+            "brightness": 36
+         }
+      ]
+   },
+   {
+      "name": "Montreal Canadiens",
+      "regex": "(montreal canadiens|montreal|canadiens|mtl|habs)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Montreal.html",
+      "twitter_handle": "CanadiensMTL",
+      "colors": [
+         {
+            "hue": 355,
+            "saturation": 62,
+            "brightness": 64
+         },
+         {
+            "hue": 218,
+            "saturation": 58,
+            "brightness": 47
+         }
+      ]
+   },
+   {
+      "name": "Nashville Predators",
+      "regex": "(nashville predators|nashville|predators|nas|preds)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Central/Nashville.html",
+      "twitter_handle": "predsnhl",
+      "colors": [
+         {
+            "hue": 35,
+            "saturation": 76,
+            "brightness": 98
+         },
+         {
+            "hue": 60,
+            "saturation": 1,
+            "brightness": 92
+         },
+         {
+            "hue": 213,
+            "saturation": 42,
+            "brightness": 42
+         }
+      ]
+   },
+   {
+      "name": "New Jersey Devils",
+      "regex": "(new jersey devils|new jersey|devils|njd)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/NewJersey.html",
+      "twitter_handle": "NHLDevils",
+      "colors": [
+         {
+            "hue": 1,
+            "saturation": 69,
+            "brightness": 76
+         },
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         }
+      ]
+   },
+   {
+      "name": "New York Islanders",
+      "regex": "(new york islanders|islanders|nyi|isles)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/NYIslanders.html",
+      "twitter_handle": "NYIslanders",
+      "colors": [
+         {
+            "hue": 210,
+            "saturation": 70,
+            "brightness": 49
+         },
+         {
+            "hue": 13,
+            "saturation": 79,
+            "brightness": 94
+         }
+      ]
+   },
+   {
+      "name": "New York Rangers",
+      "regex": "(new york rangers|rangers|nyr|blue shirts|blueshirts)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/NYRangers.html",
+      "twitter_handle": "NYRangers",
+      "colors": [
+         {
+            "hue": 1,
+            "saturation": 69,
+            "brightness": 76
+         },
+         {
+            "hue": 213,
+            "saturation": 42,
+            "brightness": 42
+         }
+      ]
+   },
+   {
+      "name": "Ottawa Senators",
+      "regex": "(ottawa senators|ottawa|senators|ott|sens)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Ottawa.html",
+      "twitter_handle": "Senators",
+      "colors": [
+         {
+            "hue": 1,
+            "saturation": 69,
+            "brightness": 76
+         },
+         {
+            "hue": 39,
+            "saturation": 82,
+            "brightness": 77
+         }
+      ]
+   },
+   {
+      "name": "Philidelphia Flyers",
+      "regex": "(philidelphia flyers|philidelphia|flyers|phi)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Philadelphia.html",
+      "twitter_handle": "NHLFlyers",
+      "colors": [
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         },
+         {
+            "hue": 13,
+            "saturation": 78,
+            "brightness": 94
+         }
+      ]
+   },
+   {
+      "name": "Arizona Coyotes",
+      "regex": "(arizona coyotes|arizona|coyotes|ari|phoenix coyotes|phoenix|phx|yotes)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Pacific/Arizona.html",
+      "twitter_handle": "ArizonaCoyotes",
+      "colors": [
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         },
+         {
+            "hue": 359,
+            "saturation": 50,
+            "brightness": 53
+         }
+      ]
+   },
+   {
+      "name": "Pittsburgh Penguins",
+      "regex": "(pittsburgh penguins|pittsburgh|penguins|pit|pitt)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Pittsburgh.html",
+      "twitter_handle": "penguins",
+      "colors": [
+         {
+            "hue": 35,
+            "saturation": 42,
+            "brightness": 72
+         },
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         }
+      ]
+   },
+   {
+      "name": "San Jose Sharks",
+      "regex": "(san jose sharks|san jose|sharks|sjs|sanjose)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Pacific/SanJose.html",
+      "twitter_handle": "SanJoseSharks",
+      "colors": [
+         {
+            "hue": 184,
+            "saturation": 100,
+            "brightness": 46
+         },
+         {
+            "hue": 0,
+            "saturation": 2,
+            "brightness": 24
+         }
+      ]
+   },
+   {
+      "name": "Tampa Bay Lightning",
+      "regex": "(tampa bay lightning|tampa bay|lightning|tbl|tampabay)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Atlantic/TampaBay.html",
+      "twitter_handle": "TBLightning",
+      "colors": [
+         {
+            "hue": 60,
+            "saturation": 1,
+            "brightness": 92
+         },
+         {
+            "hue": 210,
+            "saturation": 61,
+            "brightness": 47
+         }
+      ]
+   },
+   {
+      "name": "St. Louis Blues",
+      "regex": "(st. louis blues|st. louis|blues|stl|stlouis|saint louis|st louis|blue notes)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Central/StLouis.html",
+      "twitter_handle": "StLouisBlues",
+      "colors": [
+         {
+            "hue": 35,
+            "saturation": 76,
+            "brightness": 98
+         },
+         {
+            "hue": 213,
+            "saturation": 42,
+            "brightness": 42
+         }
+      ]
+   },
+   {
+      "name": "Toronto Maple Leafs",
+      "regex": "(toronto maple leafs|toronto|maple leafs|tor|leafs|mapleleafs)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Atlantic/Toronto.html",
+      "twitter_handle": "MapleLeafs",
+      "colors": [
+         {
+            "hue": 60,
+            "saturation": 1,
+            "brightness": 92
+         },
+         {
+            "hue": 210,
+            "saturation": 61,
+            "brightness": 47
+         }
+      ]
+   },
+   {
+      "name": "Vancouver Canucks",
+      "regex": "(vancouver canucks|vancouver|canucks|van|nucks)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Pacific/Vancouver.html",
+      "twitter_handle": "VanCanucks",
+      "colors": [
+         {
+            "hue": 223,
+            "saturation": 18,
+            "brightness": 31
+         },
+         {
+            "hue": 60,
+            "saturation": 1,
+            "brightness": 64
+         }
+      ]
+   },
+   {
+      "name": "Washington Capitals",
+      "regex": "(washington capitals|washington|capitals|wsh|caps)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Eastern/Metropolitan/Washington.html",
+      "twitter_handle": "washcaps",
+      "colors": [
+         {
+            "hue": 1,
+            "saturation": 69,
+            "brightness": 76
+         },
+         {
+            "hue": 213,
+            "saturation": 42,
+            "brightness": 42
+         }
+      ]
+   },
+   {
+      "name": "Winnipeg Jets",
+      "regex": "(winnipeg jets|winnipeg|jets|wpg|peg)",
+      "scs_url": "http://www.sportsclubstats.com/NHL/Western/Central/Winnipeg.html",
+      "twitter_handle": "NHLJets",
+      "colors": [
+         {
+            "hue": 199,
+            "saturation": 100,
+            "brightness": 57
+         },
+         {
+            "hue": 213,
+            "saturation": 42,
+            "brightness": 42
+         }
+      ]
+   }
+]


### PR DESCRIPTION
The old `seatgek.js` package was abandoned. This refactors the code to use a more up to date version with authentication support.