### PR TITLE
Handle "In Progress - Critical" bug

### DIFF
--- a/src/hockey.coffee
+++ b/src/hockey.coffee
@@ -59,9 +59,9 @@ module.exports = (robot) ->
         date = json.dates[0].date
         game = json.dates[0].games[0]
         # Handle in-progress games
-        if game.status.detailedState == 'Final'
+        if game.status.abstractGameState == 'Final'
           gameStatus = 'Final'
-        else if game.status.detailedState == 'In Progress'
+        else if game.status.abstractGameState == 'Live'
           gameStatus = "#{game.linescore.currentPeriodTimeRemaining} #{game.linescore.currentPeriodOrdinal}"
         else
           gameStatus = game.status.detailedState


### PR DESCRIPTION
If a game was near the end, it would show in the API as "In Progress - Critical" in the `detailedGameState` property. Because of the matching I was doing, that kept the time remaining from showing. This instead relies on the `abstractGameState`, which supposedly can only be `Preview`, `Live` or `Final`.