### PR TITLE
Add team color, adjust date search range

### DIFF
--- a/src/hockey.coffee
+++ b/src/hockey.coffee
@@ -45,7 +45,7 @@ module.exports = (robot) ->
       .query({
         teamId: team.nhl_stats_api_id,
         startDate: moment().tz('America/Los_Angeles').format('YYYY-MM-DD'),
-        endDate: moment().tz('America/Los_Angeles').add(7, 'd').format('YYYY-MM-DD'),
+        endDate: moment().tz('America/Los_Angeles').add(90, 'd').format('YYYY-MM-DD'),
         hydrate: 'linescore,broadcasts(all)'
       })
       .get() (err, res, body) ->
@@ -86,6 +86,7 @@ module.exports = (robot) ->
                   author_name: "NHL.com",
                   author_link: "https://nhl.com",
                   author_icon: "https://github.com/nhl.png",
+                  color: team.primary_color,
                   title: "#{moment(date).format('l')} - #{gameStatus}",
                   text: "```\n" + table.toString() + "\n```"
                   footer: game.venue.name,
@@ -120,10 +121,10 @@ module.exports = (robot) ->
           odds = []
 
           for row in output
-            odds = row if row[0] is 'ALL' and row[1] is team.moneypuck_key
+            odds = row if row[0] is 'ALL' and row[1] is team.abbreviation
 
           if !odds
-            msg.send "Could not find your odds for team #{team.moneypuck_key}"
+            msg.send "Could not find your odds for team #{team.abbreviation}"
             return
 
           # Extract relevant columns
@@ -142,8 +143,9 @@ module.exports = (robot) ->
                     author_link: "http://moneypuck.com",
                     author_name: "MoneyPuck.com",
                     fallback: fallback,
-                    thumb_url: "http://peter-tanner.com/moneypuck/logos/#{team.moneypuck_key}.png",
+                    thumb_url: "http://peter-tanner.com/moneypuck/logos/#{team.abbreviation}.png",
                     title: team.name,
+                    color: team.primary_color,
                     fields: [
                       {
                         title: "Make Playoffs",

--- a/src/teams.json
+++ b/src/teams.json
@@ -1,250 +1,290 @@
 [
    {
-      "name":"Anaheim Ducks",
-      "regex":"(anaheim ducks|anaheim|ducks|ana)",
-      "moneypuck_key":"ANA",
-      "nhl_stats_api_id":24,
-      "time_zone":"America/Los_Angeles",
-      "twitter_handle":"AnaheimDucks"
+      "name": "Anaheim Ducks",
+      "regex": "(anaheim ducks|anaheim|ducks|ana)",
+      "abbreviation": "ANA",
+      "primary_color": "#F47A38",
+      "nhl_stats_api_id": 24,
+      "time_zone": "America/Los_Angeles",
+      "twitter_handle": "AnaheimDucks"
    },
    {
-      "name":"Boston Bruins",
-      "regex":"(boston bruins|boston|bruins|bos)",
-      "moneypuck_key":"BOS",
-      "nhl_stats_api_id":6,
-      "time_zone":"America/New_York",
-      "twitter_handle":"NHLBruins"
+      "name": "Arizona Coyotes",
+      "regex": "(arizona coyotes|arizona|coyotes|ari|phoenix coyotes|phoenix|phx|yotes)",
+      "abbreviation": "ARI",
+      "primary_color": "#8C2633",
+      "nhl_stats_api_id": 53,
+      "time_zone": "America/Phoenix",
+      "twitter_handle": "ArizonaCoyotes"
    },
    {
-      "name":"Buffalo Sabres",
-      "regex":"(buffalo sabres|bufalo|sabres|buf)",
-      "moneypuck_key":"BUF",
-      "nhl_stats_api_id":7,
-      "time_zone":"America/New_York",
-      "twitter_handle":"BuffaloSabres"
+      "name": "Boston Bruins",
+      "regex": "(boston bruins|boston|bruins|bos)",
+      "abbreviation": "BOS",
+      "primary_color": "#FFB81C",
+      "nhl_stats_api_id": 6,
+      "time_zone": "America/New_York",
+      "twitter_handle": "NHLBruins"
    },
    {
-      "name":"Calgary Flames",
-      "regex":"(calgary flames|calgary|flames|cal)",
-      "moneypuck_key":"CGY",
-      "nhl_stats_api_id":20,
-      "time_zone":"America/Denver",
-      "twitter_handle":"NHLFlames"
+      "name": "Buffalo Sabres",
+      "regex": "(buffalo sabres|bufalo|sabres|buf)",
+      "abbreviation": "BUF",
+      "primary_color": "#002654",
+      "nhl_stats_api_id": 7,
+      "time_zone": "America/New_York",
+      "twitter_handle": "BuffaloSabres"
    },
    {
-      "name":"Carolina Hurricanes",
-      "regex":"(carolina hurricanes|carolina|hurricanes|car|canes)",
-      "moneypuck_key":"CAR",
-      "nhl_stats_api_id":12,
-      "time_zone":"America/New_York",
-      "twitter_handle":"NHLCanes"
+      "name": "Calgary Flames",
+      "regex": "(calgary flames|calgary|flames|cal)",
+      "abbreviation": "CGY",
+      "primary_color": "#C8102E",
+      "nhl_stats_api_id": 20,
+      "time_zone": "America/Denver",
+      "twitter_handle": "NHLFlames"
    },
    {
-      "name":"Chicago Blackhawks",
-      "regex":"(chicago blackhawks|chicago|blackhawks|chi|hawks)",
-      "moneypuck_key":"CHI",
-      "nhl_stats_api_id":16,
-      "time_zone":"America/Chicago",
-      "twitter_handle":"NHLBlackhawks"
+      "name": "Carolina Hurricanes",
+      "regex": "(carolina hurricanes|carolina|hurricanes|car|canes)",
+      "abbreviation": "CAR",
+      "primary_color": "#CC0000",
+      "nhl_stats_api_id": 12,
+      "time_zone": "America/New_York",
+      "twitter_handle": "NHLCanes"
    },
    {
-      "name":"Colorado Avalanche",
-      "regex":"(colorado avalanche|colorado|avalanche|col|avs|denver)",
-      "moneypuck_key":"COL",
-      "nhl_stats_api_id":21,
-      "time_zone":"America/Denver",
-      "twitter_handle":"Avalanche"
+      "name": "Chicago Blackhawks",
+      "regex": "(chicago blackhawks|chicago|blackhawks|chi|hawks)",
+      "abbreviation": "CHI",
+      "primary_color": "#CF0A2C",
+      "nhl_stats_api_id": 16,
+      "time_zone": "America/Chicago",
+      "twitter_handle": "NHLBlackhawks"
    },
    {
-      "name":"Columbus Blue Jackets",
-      "regex":"(columbus blue jackets|columbus|blue jackets|cbj|bluejackets)",
-      "moneypuck_key":"CBJ",
-      "nhl_stats_api_id":29,
-      "time_zone":"America/New_York",
-      "twitter_handle":"BlueJacketsNHL"
+      "name": "Colorado Avalanche",
+      "regex": "(colorado avalanche|colorado|avalanche|col|avs|denver)",
+      "abbreviation": "COL",
+      "primary_color": "#6F263D",
+      "nhl_stats_api_id": 21,
+      "time_zone": "America/Denver",
+      "twitter_handle": "Avalanche"
    },
    {
-      "name":"Dallas Stars",
-      "regex":"(dallas stars|dallas|stars|dal)",
-      "moneypuck_key":"DAL",
-      "nhl_stats_api_id":25,
-      "time_zone":"America/Chicago",
-      "twitter_handle":"DallasStars"
+      "name": "Columbus Blue Jackets",
+      "regex": "(columbus blue jackets|columbus|blue jackets|cbj|bluejackets)",
+      "abbreviation": "CBJ",
+      "primary_color": "#002654",
+      "nhl_stats_api_id": 29,
+      "time_zone": "America/New_York",
+      "twitter_handle": "BlueJacketsNHL"
    },
    {
-      "name":"Detroit Red Wings",
-      "regex":"(detroit red wings|detroit|red wings|det|redwings|wings)",
-      "moneypuck_key":"DET",
-      "nhl_stats_api_id":17,
-      "time_zone":"America/Detroit",
-      "twitter_handle":"DetroitRedWings"
+      "name": "Dallas Stars",
+      "regex": "(dallas stars|dallas|stars|dal)",
+      "abbreviation": "DAL",
+      "primary_color": "#006847",
+      "nhl_stats_api_id": 25,
+      "time_zone": "America/Chicago",
+      "twitter_handle": "DallasStars"
    },
    {
-      "name":"Edmonton Oilers",
-      "regex":"(edmonton oilers|edmonton|oilers|edm|oil)",
-      "moneypuck_key":"EDM",
-      "nhl_stats_api_id":22,
-      "time_zone":"America/Edmonton",
-      "twitter_handle":"EdmontonOilers"
+      "name": "Detroit Red Wings",
+      "regex": "(detroit red wings|detroit|red wings|det|redwings|wings)",
+      "abbreviation": "DET",
+      "primary_color": "#CE1126",
+      "nhl_stats_api_id": 17,
+      "time_zone": "America/Detroit",
+      "twitter_handle": "DetroitRedWings"
    },
    {
-      "name":"Florida Panthers",
-      "regex":"(florida panthers|florida|panthers|fla|cats)",
-      "moneypuck_key":"FLA",
-      "nhl_stats_api_id":13,
-      "time_zone":"America/New_York",
-      "twitter_handle":"FlaPanthers"
+      "name": "Edmonton Oilers",
+      "regex": "(edmonton oilers|edmonton|oilers|edm|oil)",
+      "abbreviation": "EDM",
+      "primary_color": "#041E42",
+      "nhl_stats_api_id": 22,
+      "time_zone": "America/Edmonton",
+      "twitter_handle": "EdmontonOilers"
    },
    {
-      "name":"Los Angeles Kings",
-      "regex":"(los angeles kings|los angeles|kings|lak|losangeles)",
-      "moneypuck_key":"LAK",
-      "nhl_stats_api_id":26,
-      "time_zone":"America/Los_Angeles",
-      "twitter_handle":"LAKings"
+      "name": "Florida Panthers",
+      "regex": "(florida panthers|florida|panthers|fla|cats)",
+      "abbreviation": "FLA",
+      "primary_color": "#041E42",
+      "nhl_stats_api_id": 13,
+      "time_zone": "America/New_York",
+      "twitter_handle": "FlaPanthers"
    },
    {
-      "name":"Minnesota Wild",
-      "regex":"(minnesota wild|minnesota|wild|min)",
-      "moneypuck_key":"MIN",
-      "nhl_stats_api_id":30,
-      "time_zone":"America/Chicago",
-      "twitter_handle":"mnwild"
+      "name": "Los Angeles Kings",
+      "regex": "(los angeles kings|los angeles|kings|lak|losangeles)",
+      "abbreviation": "LAK",
+      "primary_color": "#111111",
+      "nhl_stats_api_id": 26,
+      "time_zone": "America/Los_Angeles",
+      "twitter_handle": "LAKings"
    },
    {
-      "name":"Montreal Canadiens",
-      "regex":"(montreal canadiens|montreal|canadiens|mtl|habs)",
-      "moneypuck_key":"MTL",
-      "nhl_stats_api_id":8,
-      "time_zone":"America/Montreal",
-      "twitter_handle":"CanadiensMTL"
+      "name": "Minnesota Wild",
+      "regex": "(minnesota wild|minnesota|wild|min)",
+      "abbreviation": "MIN",
+      "primary_color": "#154734",
+      "nhl_stats_api_id": 30,
+      "time_zone": "America/Chicago",
+      "twitter_handle": "mnwild"
    },
    {
-      "name":"Nashville Predators",
-      "regex":"(nashville predators|nashville|predators|nas|preds)",
-      "moneypuck_key":"NSH",
-      "nhl_stats_api_id":18,
-      "time_zone":"America/Chicago",
-      "twitter_handle":"predsnhl"
+      "name": "Montreal Canadiens",
+      "regex": "(montreal canadiens|montreal|canadiens|mtl|habs)",
+      "abbreviation": "MTL",
+      "primary_color": "#AF1E2D",
+      "nhl_stats_api_id": 8,
+      "time_zone": "America/Montreal",
+      "twitter_handle": "CanadiensMTL"
    },
    {
-      "name":"New Jersey Devils",
-      "regex":"(new jersey devils|new jersey|devils|njd)",
-      "moneypuck_key":"NJD",
-      "nhl_stats_api_id":1,
-      "time_zone":"America/New_York",
-      "twitter_handle":"NHLDevils"
+      "name": "Nashville Predators",
+      "regex": "(nashville predators|nashville|predators|nas|preds)",
+      "abbreviation": "NSH",
+      "primary_color": "#FFB81C",
+      "nhl_stats_api_id": 18,
+      "time_zone": "America/Chicago",
+      "twitter_handle": "predsnhl"
    },
    {
-      "name":"New York Islanders",
-      "regex":"(new york islanders|islanders|nyi|isles)",
-      "moneypuck_key":"NYI",
-      "nhl_stats_api_id":2,
-      "time_zone":"America/New_York",
-      "twitter_handle":"NYIslanders"
+      "name": "New Jersey Devils",
+      "regex": "(new jersey devils|new jersey|devils|njd)",
+      "abbreviation": "NJD",
+      "primary_color": "#CE1126",
+      "nhl_stats_api_id": 1,
+      "time_zone": "America/New_York",
+      "twitter_handle": "NHLDevils"
    },
    {
-      "name":"New York Rangers",
-      "regex":"(new york rangers|rangers|nyr|blue shirts|blueshirts)",
-      "moneypuck_key":"NYR",
-      "nhl_stats_api_id":3,
-      "time_zone":"America/New_York",
-      "twitter_handle":"NYRangers"
+      "name": "New York Islanders",
+      "regex": "(new york islanders|islanders|nyi|isles)",
+      "abbreviation": "NYI",
+      "primary_color": "#00539B",
+      "nhl_stats_api_id": 2,
+      "time_zone": "America/New_York",
+      "twitter_handle": "NYIslanders"
    },
    {
-      "name":"Ottawa Senators",
-      "regex":"(ottawa senators|ottawa|senators|ott|sens)",
-      "moneypuck_key":"OTT",
-      "nhl_stats_api_id":9,
-      "time_zone":"America/New_York",
-      "twitter_handle":"Senators"
+      "name": "New York Rangers",
+      "regex": "(new york rangers|rangers|nyr|blue shirts|blueshirts)",
+      "abbreviation": "NYR",
+      "primary_color": "#0038A8",
+      "nhl_stats_api_id": 3,
+      "time_zone": "America/New_York",
+      "twitter_handle": "NYRangers"
    },
    {
-      "name":"Philidelphia Flyers",
-      "regex":"(philidelphia flyers|philidelphia|flyers|phi)",
-      "moneypuck_key":"PHI",
-      "nhl_stats_api_id":4,
-      "time_zone":"America/New_York",
-      "twitter_handle":"NHLFlyers"
+      "name": "Ottawa Senators",
+      "regex": "(ottawa senators|ottawa|senators|ott|sens)",
+      "abbreviation": "OTT",
+      "primary_color": "#C52032",
+      "nhl_stats_api_id": 9,
+      "time_zone": "America/New_York",
+      "twitter_handle": "Senators"
    },
    {
-      "name":"Arizona Coyotes",
-      "regex":"(arizona coyotes|arizona|coyotes|ari|phoenix coyotes|phoenix|phx|yotes)",
-      "moneypuck_key":"ARI",
-      "nhl_stats_api_id":53,
-      "time_zone":"America/Phoenix",
-      "twitter_handle":"ArizonaCoyotes"
+      "name": "Philidelphia Flyers",
+      "regex": "(philidelphia flyers|philidelphia|flyers|phi)",
+      "abbreviation": "PHI",
+      "primary_color": "#F74902",
+      "nhl_stats_api_id": 4,
+      "time_zone": "America/New_York",
+      "twitter_handle": "NHLFlyers"
    },
    {
-      "name":"Pittsburgh Penguins",
-      "regex":"(pittsburgh penguins|pittsburgh|penguins|pit|pitt)",
-      "moneypuck_key":"PIT",
-      "nhl_stats_api_id":5,
-      "time_zone":"America/New_York",
-      "twitter_handle":"penguins"
+      "name": "Pittsburgh Penguins",
+      "regex": "(pittsburgh penguins|pittsburgh|penguins|pit|pitt)",
+      "abbreviation": "PIT",
+      "primary_color": "#000000",
+      "nhl_stats_api_id": 5,
+      "time_zone": "America/New_York",
+      "twitter_handle": "penguins"
    },
    {
-      "name":"San Jose Sharks",
-      "regex":"(san jose sharks|san jose|sharks|sjs|sanjose)",
-      "moneypuck_key":"SJS",
-      "nhl_stats_api_id":28,
-      "time_zone":"America/Los_Angeles",
-      "twitter_handle":"SanJoseSharks"
+      "name": "St. Louis Blues",
+      "regex": "(st. louis blues|st. louis|blues|stl|stlouis|saint louis|st louis|blue notes)",
+      "abbreviation": "STL",
+      "primary_color": "#002F87",
+      "nhl_stats_api_id": 19,
+      "time_zone": "America/Chicago",
+      "twitter_handle": "StLouisBlues"
    },
    {
-      "name":"Tampa Bay Lightning",
-      "regex":"(tampa bay lightning|tampa bay|lightning|tbl|tampabay|bolts)",
-      "moneypuck_key":"TBL",
-      "nhl_stats_api_id":14,
-      "time_zone":"America/New_York",
-      "twitter_handle":"TBLightning"
+      "name": "San Jose Sharks",
+      "regex": "(san jose sharks|san jose|sharks|sjs|sanjose)",
+      "abbreviation": "SJS",
+      "primary_color": "#006D75",
+      "nhl_stats_api_id": 28,
+      "time_zone": "America/Los_Angeles",
+      "twitter_handle": "SanJoseSharks"
    },
    {
-      "name":"St. Louis Blues",
-      "regex":"(st. louis blues|st. louis|blues|stl|stlouis|saint louis|st louis|blue notes)",
-      "moneypuck_key":"STL",
-      "nhl_stats_api_id":19,
-      "time_zone":"America/Chicago",
-      "twitter_handle":"StLouisBlues"
+      "name": "Tampa Bay Lightning",
+      "regex": "(tampa bay lightning|tampa bay|lightning|tbl|tampabay|bolts)",
+      "abbreviation": "TBL",
+      "primary_color": "#002868",
+      "nhl_stats_api_id": 14,
+      "time_zone": "America/New_York",
+      "twitter_handle": "TBLightning"
    },
    {
-      "name":"Toronto Maple Leafs",
-      "regex":"(toronto maple leafs|toronto|maple leafs|tor|leafs|mapleleafs)",
-      "moneypuck_key":"TOR",
-      "nhl_stats_api_id":10,
-      "time_zone":"America/New_York",
-      "twitter_handle":"MapleLeafs"
+      "name": "Toronto Maple Leafs",
+      "regex": "(toronto maple leafs|toronto|maple leafs|tor|leafs|mapleleafs)",
+      "abbreviation": "TOR",
+      "primary_color": "#00205B",
+      "nhl_stats_api_id": 10,
+      "time_zone": "America/New_York",
+      "twitter_handle": "MapleLeafs"
    },
    {
-      "name":"Vancouver Canucks",
-      "regex":"(vancouver canucks|vancouver|canucks|van|nucks)",
-      "moneypuck_key":"VAN",
-      "nhl_stats_api_id":23,
-      "time_zone":"America/Vancouver",
-      "twitter_handle":"VanCanucks"
+      "name": "Vancouver Canucks",
+      "regex": "(vancouver canucks|vancouver|canucks|van|nucks)",
+      "abbreviation": "VAN",
+      "primary_color": "#00205B",
+      "nhl_stats_api_id": 23,
+      "time_zone": "America/Vancouver",
+      "twitter_handle": "VanCanucks"
    },
    {
-      "name":"Vegas Golden Knights",
-      "regex":"(vegas golden knights|vegas|knights|vgk)",
-      "moneypuck_key":"VGK",
-      "nhl_stats_api_id":54,
-      "time_zone":"America/Los_Angeles",
-      "twitter_handle":"GoldenKnights"
+      "name": "Vegas Golden Knights",
+      "regex": "(vegas golden knights|vegas|knights|vgk)",
+      "abbreviation": "VGK",
+      "primary_color": "#B4975A",
+      "nhl_stats_api_id": 54,
+      "time_zone": "America/Los_Angeles",
+      "twitter_handle": "GoldenKnights"
    },
    {
-      "name":"Washington Capitals",
-      "regex":"(washington capitals|washington|capitals|wsh|caps)",
-      "moneypuck_key":"WSH",
-      "nhl_stats_api_id":15,
-      "time_zone":"America/New_York",
-      "twitter_handle":"washcaps"
+      "name": "Washington Capitals",
+      "regex": "(washington capitals|washington|capitals|wsh|caps)",
+      "abbreviation": "WSH",
+      "primary_color": "#",
+      "nhl_stats_api_id": 15,
+      "time_zone": "America/New_York",
+      "twitter_handle": "washcaps"
    },
    {
-      "name":"Winnipeg Jets",
-      "regex":"(winnipeg jets|winnipeg|jets|wpg|peg)",
-      "moneypuck_key":"WPG",
-      "nhl_stats_api_id":52,
-      "time_zone":"America/Winnipeg",
-      "twitter_handle":"NHLJets"
+      "name": "Winnipeg Jets",
+      "regex": "(winnipeg jets|winnipeg|jets|wpg|peg)",
+      "abbreviation": "WPG",
+      "primary_color": "#C8102E",
+      "nhl_stats_api_id": 52,
+      "time_zone": "America/Winnipeg",
+      "twitter_handle": "NHLJets"
+   },
+   {
+      "name": "Seattle Kraken",
+      "regex": "(seattle kraken|seattle|kraken|sea|kraks)",
+      "abbreviation": "SEA",
+      "primary_color": "#001628",
+      "nhl_stats_api_id": 55,
+      "time_zone": "America/Los_Angeles",
+      "twitter_handle": "NHLSeattle_"
    }
 ]

--- a/src/teams.json
+++ b/src/teams.json
@@ -225,6 +225,15 @@
       "twitter_handle": "SanJoseSharks"
    },
    {
+      "name": "Seattle Kraken",
+      "regex": "(seattle kraken|seattle|kraken|sea|kraks)",
+      "abbreviation": "SEA",
+      "primary_color": "#001628",
+      "nhl_stats_api_id": 55,
+      "time_zone": "America/Los_Angeles",
+      "twitter_handle": "NHLSeattle_"
+   },
+   {
       "name": "Tampa Bay Lightning",
       "regex": "(tampa bay lightning|tampa bay|lightning|tbl|tampabay|bolts)",
       "abbreviation": "TBL",
@@ -277,14 +286,5 @@
       "nhl_stats_api_id": 52,
       "time_zone": "America/Winnipeg",
       "twitter_handle": "NHLJets"
-   },
-   {
-      "name": "Seattle Kraken",
-      "regex": "(seattle kraken|seattle|kraken|sea|kraks)",
-      "abbreviation": "SEA",
-      "primary_color": "#001628",
-      "nhl_stats_api_id": 55,
-      "time_zone": "America/Los_Angeles",
-      "twitter_handle": "NHLSeattle_"
    }
 ]

--- a/test/hockey-slack_test.coffee
+++ b/test/hockey-slack_test.coffee
@@ -41,7 +41,7 @@ describe 'hubot-hockey for slack', ->
       .query({
         teamId: 18,
         startDate: '2019-10-10',
-        endDate: '2019-10-17',
+        endDate: '2020-01-08',
         hydrate: 'linescore,broadcasts(all)'
       })
       .delay({
@@ -70,6 +70,7 @@ describe 'hubot-hockey for slack', ->
                   "author_name": "NHL.com",
                   "author_link": "https://nhl.com",
                   "author_icon": "https://github.com/nhl.png",
+                  "color": "#FFB81C",
                   "title": "10/10/2019 - Final",
                   "text": "```\n  Washington Capitals (2-1-2)   5  \n  Nashville Predators (3-1-0)   6  \n```",
                   "footer": "Bridgestone Arena",
@@ -87,6 +88,7 @@ describe 'hubot-hockey for slack', ->
                   "author_name": "MoneyPuck.com",
                   "author_link": "http://moneypuck.com",
                   "author_icon": "http://peter-tanner.com/moneypuck/logos/moneypucklogo.png",
+                  "color": "#FFB81C",
                   "title": "Nashville Predators",
                   "thumb_url": "http://peter-tanner.com/moneypuck/logos/NSH.png",
                   "fields": [
@@ -121,7 +123,7 @@ describe 'hubot-hockey for slack', ->
       .query({
         teamId: 18,
         startDate: '2019-12-19',
-        endDate: '2019-12-26',
+        endDate: '2020-03-18',
         hydrate: 'linescore,broadcasts(all)'
       })
       .delay({
@@ -150,6 +152,7 @@ describe 'hubot-hockey for slack', ->
                   "author_name": "NHL.com",
                   "author_link": "https://nhl.com",
                   "author_icon": "https://github.com/nhl.png",
+                  "color": "#FFB81C",
                   "title": "12/19/2019 - Final/OT",
                   "text": "```\n  Nashville Predators (16-12-6)   4  \n  Ottawa Senators (15-18-3)       5  \n```",
                   "footer": "Canadian Tire Centre",
@@ -167,6 +170,7 @@ describe 'hubot-hockey for slack', ->
                   "author_name": "MoneyPuck.com",
                   "author_link": "http://moneypuck.com",
                   "author_icon": "http://peter-tanner.com/moneypuck/logos/moneypucklogo.png",
+                  "color": "#FFB81C",
                   "title": "Nashville Predators",
                   "thumb_url": "http://peter-tanner.com/moneypuck/logos/NSH.png",
                   "fields": [
@@ -201,7 +205,7 @@ describe 'hubot-hockey for slack', ->
       .query({
         teamId: 18,
         startDate: '2019-10-15',
-        endDate: '2019-10-22',
+        endDate: '2020-01-13',
         hydrate: 'linescore,broadcasts(all)'
       })
       .delay({
@@ -230,6 +234,7 @@ describe 'hubot-hockey for slack', ->
                   "author_name": "NHL.com",
                   "author_link": "https://nhl.com",
                   "author_icon": "https://github.com/nhl.png",
+                  "color": "#FFB81C",
                   "title": "10/15/2019 - 9:00 pm CDT",
                   "text": "```\n  Nashville Predators (3-2-0)    0  \n  Vegas Golden Knights (4-2-0)   0  \n```",
                   "footer": "T-Mobile Arena",
@@ -247,6 +252,7 @@ describe 'hubot-hockey for slack', ->
                   "author_name": "MoneyPuck.com",
                   "author_link": "http://moneypuck.com",
                   "author_icon": "http://peter-tanner.com/moneypuck/logos/moneypucklogo.png",
+                  "color": "#FFB81C",
                   "title": "Nashville Predators",
                   "thumb_url": "http://peter-tanner.com/moneypuck/logos/NSH.png",
                   "fields": [
@@ -281,7 +287,7 @@ describe 'hubot-hockey for slack', ->
       .query({
         teamId: 18,
         startDate: '2019-10-12',
-        endDate: '2019-10-19',
+        endDate: '2020-01-10',
         hydrate: 'linescore,broadcasts(all)'
       })
       .delay({
@@ -310,6 +316,7 @@ describe 'hubot-hockey for slack', ->
                   "author_name": "NHL.com",
                   "author_link": "https://nhl.com",
                   "author_icon": "https://github.com/nhl.png",
+                  "color": "#FFB81C",
                   "title": "10/12/2019 - 04:23 1st",
                   "text": "```\n  Nashville Predators (3-1-0)   1  \n  Los Angeles Kings (1-2-0)     2  \n```",
                   "footer": "STAPLES Center",
@@ -327,6 +334,7 @@ describe 'hubot-hockey for slack', ->
                   "author_name": "MoneyPuck.com",
                   "author_link": "http://moneypuck.com",
                   "author_icon": "http://peter-tanner.com/moneypuck/logos/moneypucklogo.png",
+                  "color": "#FFB81C",
                   "title": "Nashville Predators",
                   "thumb_url": "http://peter-tanner.com/moneypuck/logos/NSH.png",
                   "fields": [

--- a/test/hockey_test.coffee
+++ b/test/hockey_test.coffee
@@ -40,7 +40,7 @@ describe 'hubot-hockey', ->
       .query({
         teamId: 18,
         startDate: '2019-10-10',
-        endDate: '2019-10-17',
+        endDate: '2020-01-08',
         hydrate: 'linescore,broadcasts(all)'
       })
       .delay({
@@ -79,7 +79,7 @@ describe 'hubot-hockey', ->
       .query({
         teamId: 18,
         startDate: '2019-12-19',
-        endDate: '2019-12-26',
+        endDate: '2020-03-18',
         hydrate: 'linescore,broadcasts(all)'
       })
       .delay({
@@ -117,7 +117,7 @@ describe 'hubot-hockey', ->
       .query({
         teamId: 18,
         startDate: '2019-10-12',
-        endDate: '2019-10-19',
+        endDate: '2020-01-10',
         hydrate: 'linescore,broadcasts(all)'
       })
       .delay({
@@ -155,7 +155,7 @@ describe 'hubot-hockey', ->
       .query({
         teamId: 18,
         startDate: '2019-10-15',
-        endDate: '2019-10-22',
+        endDate: '2020-01-13',
         hydrate: 'linescore,broadcasts(all)'
       })
       .delay({


### PR DESCRIPTION
- Adds team primary color for Slack formatting
- Increases the search range to 90 days from 7
- Add Seattle's new team