### PR TITLE
Add broadcast information to output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "hubot-hockey",
       "version": "4.1.11",
       "license": "MIT",
       "dependencies": {

--- a/src/hockey.coffee
+++ b/src/hockey.coffee
@@ -84,6 +84,13 @@ module.exports = (robot) ->
           table.addRow "#{game.teams.home.team.name} (#{game.teams.home.leagueRecord.wins}-#{game.teams.home.leagueRecord.losses})", "#{game.teams.home.score}"
         table.removeBorder()
 
+        howToWatch = game.venue.name
+        if game.broadcasts.length > 0
+          networks = []
+          for broadcast in game.broadcasts
+            networks.push "#{broadcast.name} (#{broadcast.type})"
+          howToWatch = howToWatch + "; TV: " + networks.join(' | ')
+
         # Say it
         switch robot.adapterName
           when 'slack'
@@ -98,13 +105,13 @@ module.exports = (robot) ->
                   color: team.primary_color,
                   title: "#{moment(date).format('l')} - #{gameStatus}",
                   text: "```\n" + table.toString() + "\n```"
-                  footer: game.venue.name,
+                  footer: "#{howToWatch}",
                   mrkdwn_in: ["text", "pretext"]
                 }
               ]
             }
           else
-            msg.send "#{moment(date).format('l')} - #{game.venue.name}"
+            msg.send "#{moment(date).format('l')} - #{howToWatch}"
             msg.send table.toString()
             msg.send "#{gameStatus} - https://www.nhl.com/gamecenter/#{game.gamePk}"
         if typeof cb == 'function'

--- a/test/hockey-slack_test.coffee
+++ b/test/hockey-slack_test.coffee
@@ -73,7 +73,7 @@ describe 'hubot-hockey for slack', ->
                   "color": "#FFB81C",
                   "title": "10/10/2019 - Final",
                   "text": "```\n  Washington Capitals (2-1-2)   5  \n  Nashville Predators (3-1-0)   6  \n```",
-                  "footer": "Bridgestone Arena",
+                  "footer": "Bridgestone Arena; TV: FS-TN (home) | NBCSWA (away)",
                   "mrkdwn_in": ["text", "pretext"]
                 }
               ]
@@ -155,7 +155,7 @@ describe 'hubot-hockey for slack', ->
                   "color": "#FFB81C",
                   "title": "12/19/2019 - Final/OT",
                   "text": "```\n  Nashville Predators (16-12-6)   4  \n  Ottawa Senators (15-18-3)       5  \n```",
-                  "footer": "Canadian Tire Centre",
+                  "footer": "Canadian Tire Centre; TV: ESPN+ (national) | RDS2 (home) | TSN5 (home) | FS-TN (away)",
                   "mrkdwn_in": ["text", "pretext"]
                 }
               ]
@@ -237,7 +237,7 @@ describe 'hubot-hockey for slack', ->
                   "color": "#002868",
                   "title": "8/11/2020 - Final/5OT - Lighting lead 1-0",
                   "text": "```\n  Columbus Blue Jackets (3-3-0)   2  \n  Tampa Bay Lightning (3-1-0)     3  \n```",
-                  "footer": "Scotiabank Arena",
+                  "footer": "Scotiabank Arena; TV: NBCSN (national) | TVAS (national) | SN (national) | SUN (home) | FS-O (away)",
                   "mrkdwn_in": ["text", "pretext"]
                 }
               ]
@@ -319,7 +319,7 @@ describe 'hubot-hockey for slack', ->
                   "color": "#FFB81C",
                   "title": "10/15/2019 - 9:00 pm CDT",
                   "text": "```\n  Nashville Predators (3-2-0)    0  \n  Vegas Golden Knights (4-2-0)   0  \n```",
-                  "footer": "T-Mobile Arena",
+                  "footer": "T-Mobile Arena; TV: ESPN+ (national) | ATTSN-RM (home) | FS-TN (away)",
                   "mrkdwn_in": ["text", "pretext"]
                 }
               ]
@@ -401,7 +401,7 @@ describe 'hubot-hockey for slack', ->
                   "color": "#FFB81C",
                   "title": "10/12/2019 - 04:23 1st",
                   "text": "```\n  Nashville Predators (3-1-0)   1  \n  Los Angeles Kings (1-2-0)     2  \n```",
-                  "footer": "STAPLES Center",
+                  "footer": "STAPLES Center; TV: FS-W (home) | FS-TN (away)",
                   "mrkdwn_in": ["text", "pretext"]
                 }
               ]
@@ -483,7 +483,7 @@ describe 'hubot-hockey for slack', ->
                   "color": "#FFB81C",
                   "title": "7/30/2020 - 3:00 pm CDT - Preseason",
                   "text": "```\n  Nashville Predators (0-0)   0  \n  Dallas Stars (0-0)          0  \n```",
-                  "footer": "Rogers Place",
+                  "footer": "Rogers Place; TV: NHLN (national) | FS-SW (home) | FS-TN (away)",
                   "mrkdwn_in": ["text", "pretext"]
                 }
               ]

--- a/test/hockey_test.coffee
+++ b/test/hockey_test.coffee
@@ -59,7 +59,7 @@ describe 'hubot-hockey', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot preds']
-          ['hubot', '10/10/2019 - Bridgestone Arena']
+          ['hubot', '10/10/2019 - Bridgestone Arena; TV: FS-TN (home) | NBCSWA (away)']
           ['hubot', "  Washington Capitals (2-1-2)   5  \n  Nashville Predators (3-1-0)   6  "]
           ['hubot', 'Final - https://www.nhl.com/gamecenter/2019020052']
           ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%']
@@ -98,7 +98,7 @@ describe 'hubot-hockey', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot preds']
-          ['hubot', '12/19/2019 - Canadian Tire Centre']
+          ['hubot', '12/19/2019 - Canadian Tire Centre; TV: ESPN+ (national) | RDS2 (home) | TSN5 (home) | FS-TN (away)']
           ['hubot', "  Nashville Predators (16-12-6)   4  \n  Ottawa Senators (15-18-3)       5  "]
           ['hubot', 'Final/OT - https://www.nhl.com/gamecenter/2019020542']
           ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%']
@@ -137,7 +137,7 @@ describe 'hubot-hockey', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot bolts']
-          ['hubot', '8/11/2020 - Scotiabank Arena']
+          ['hubot', '8/11/2020 - Scotiabank Arena; TV: NBCSN (national) | TVAS (national) | SN (national) | SUN (home) | FS-O (away)']
           ['hubot', "  Columbus Blue Jackets (3-3-0)   2  \n  Tampa Bay Lightning (3-1-0)     3  "]
           ['hubot', 'Final/5OT - Lighting lead 1-0 - https://www.nhl.com/gamecenter/2019030121']
           ['hubot', 'Odds to Win Stanley Cup: 3.1%']
@@ -175,7 +175,7 @@ describe 'hubot-hockey', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot preds']
-          ['hubot', '10/12/2019 - STAPLES Center']
+          ['hubot', '10/12/2019 - STAPLES Center; TV: FS-W (home) | FS-TN (away)']
           ['hubot', "  Nashville Predators (3-1-0)   1  \n  Los Angeles Kings (1-2-0)     2  "]
           ['hubot', '04:23 1st - https://www.nhl.com/gamecenter/2019020063']
           ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%']
@@ -213,7 +213,7 @@ describe 'hubot-hockey', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot preds']
-          ['hubot', '10/15/2019 - T-Mobile Arena']
+          ['hubot', '10/15/2019 - T-Mobile Arena; TV: ESPN+ (national) | ATTSN-RM (home) | FS-TN (away)']
           ['hubot', "  Nashville Predators (3-2-0)    0  \n  Vegas Golden Knights (4-2-0)   0  "]
           ['hubot', '9:00 pm CDT - https://www.nhl.com/gamecenter/2019020090']
           ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%']
@@ -251,7 +251,7 @@ describe 'hubot-hockey', ->
       try
         expect(selfRoom.messages).to.eql [
           ['alice', '@hubot preds']
-          ['hubot', '7/30/2020 - Rogers Place']
+          ['hubot', '7/30/2020 - Rogers Place; TV: NHLN (national) | FS-SW (home) | FS-TN (away)']
           ['hubot', "  Nashville Predators (0-0)   0  \n  Dallas Stars (0-0)          0  "]
           ['hubot', '3:00 pm CDT - Preseason - https://www.nhl.com/gamecenter/2019011010']
           ['hubot', 'Odds to Win Stanley Cup: 1.6%']


### PR DESCRIPTION
With the changing media landscape, it might be slightly harder to figure out which channel the game is on. This PR adds the information we can get from the API.