### PR TITLE
Show NHL division standings

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ See full instructions [here](https://github.com/github/hubot/blob/master/docs/sc
 ## Commands
 
 - `hubot <team>` - Show your team's current playoff odds and next game
+- `hubot nhl [division]` - Show division leaders or division standings

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "sinon-chai": "^3.7.0"
       },
       "peerDependencies": {
-        "hubot": "^3 || ^4"
+        "hubot": ">=2 <10 || 0.0.0-development"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2340,9 +2340,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"
@@ -4260,12 +4260,20 @@
       }
     },
     "node_modules/nock/node_modules/debug": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/nock/node_modules/ms": {
@@ -8446,9 +8454,9 @@
       "dev": true
     },
     "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true
     },
     "get-intrinsic": {
@@ -9818,12 +9826,12 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "moment-timezone": "^0.5.43"
   },
   "peerDependencies": {
-    "hubot": "^3 || ^4"
+    "hubot": ">=2 <10 || 0.0.0-development"
   },
   "devDependencies": {
     "chai": "^4.3.7",

--- a/test/fixtures/nhl-statsapi-standings.json
+++ b/test/fixtures/nhl-statsapi-standings.json
@@ -1,0 +1,3140 @@
+{
+  "copyright" : "NHL and the NHL Shield are registered trademarks of the National Hockey League. NHL and NHL team marks are the property of the NHL and its teams. © NHL 2023. All Rights Reserved.",
+  "records" : [ {
+    "standingsType" : "regularSeason",
+    "league" : {
+      "id" : 133,
+      "name" : "National Hockey League",
+      "link" : "/api/v1/league/133"
+    },
+    "division" : {
+      "id" : 18,
+      "name" : "Metropolitan",
+      "nameShort" : "Metro",
+      "link" : "/api/v1/divisions/18",
+      "abbreviation" : "M"
+    },
+    "conference" : {
+      "id" : 6,
+      "name" : "Eastern",
+      "link" : "/api/v1/conferences/6"
+    },
+    "teamRecords" : [ {
+      "team" : {
+        "id" : 12,
+        "name" : "Carolina Hurricanes",
+        "link" : "/api/v1/teams/12"
+      },
+      "leagueRecord" : {
+        "wins" : 52,
+        "losses" : 21,
+        "ot" : 9,
+        "type" : "league"
+      },
+      "regulationWins" : 39,
+      "goalsAgainst" : 213,
+      "goalsScored" : 266,
+      "points" : 113,
+      "divisionRank" : "1",
+      "divisionL10Rank" : "5",
+      "divisionRoadRank" : "3",
+      "divisionHomeRank" : "1",
+      "conferenceRank" : "2",
+      "conferenceL10Rank" : "10",
+      "conferenceRoadRank" : "4",
+      "conferenceHomeRank" : "4",
+      "leagueRank" : "2",
+      "leagueL10Rank" : "21",
+      "leagueRoadRank" : "9",
+      "leagueHomeRank" : "4",
+      "wildCardRank" : "0",
+      "row" : 48,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 2,
+        "streakCode" : "W2"
+      },
+      "clinchIndicator" : "y",
+      "pointsPercentage" : 0.6890243902439024,
+      "ppDivisionRank" : "1",
+      "ppConferenceRank" : "2",
+      "ppLeagueRank" : "2",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 9,
+          "losses" : 4,
+          "ot" : 3,
+          "type" : "Central"
+        }, {
+          "wins" : 15,
+          "losses" : 7,
+          "ot" : 2,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 9,
+          "losses" : 4,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 19,
+          "losses" : 6,
+          "ot" : 1,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 28,
+          "losses" : 10,
+          "ot" : 3,
+          "type" : "home"
+        }, {
+          "wins" : 24,
+          "losses" : 11,
+          "ot" : 6,
+          "type" : "away"
+        }, {
+          "wins" : 4,
+          "losses" : 3,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 5,
+          "losses" : 5,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 34,
+          "losses" : 13,
+          "ot" : 3,
+          "type" : "Eastern"
+        }, {
+          "wins" : 18,
+          "losses" : 8,
+          "ot" : 6,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 1,
+        "name" : "New Jersey Devils",
+        "link" : "/api/v1/teams/1"
+      },
+      "leagueRecord" : {
+        "wins" : 52,
+        "losses" : 22,
+        "ot" : 8,
+        "type" : "league"
+      },
+      "regulationWins" : 39,
+      "goalsAgainst" : 226,
+      "goalsScored" : 291,
+      "points" : 112,
+      "divisionRank" : "2",
+      "divisionL10Rank" : "1",
+      "divisionRoadRank" : "1",
+      "divisionHomeRank" : "3",
+      "conferenceRank" : "3",
+      "conferenceL10Rank" : "4",
+      "conferenceRoadRank" : "2",
+      "conferenceHomeRank" : "6",
+      "leagueRank" : "3",
+      "leagueL10Rank" : "8",
+      "leagueRoadRank" : "2",
+      "leagueHomeRank" : "11",
+      "wildCardRank" : "0",
+      "row" : 50,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 2,
+        "streakCode" : "W2"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.6829268292682927,
+      "ppDivisionRank" : "2",
+      "ppConferenceRank" : "3",
+      "ppLeagueRank" : "3",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 8,
+          "losses" : 5,
+          "ot" : 3,
+          "type" : "Central"
+        }, {
+          "wins" : 12,
+          "losses" : 11,
+          "ot" : 1,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 14,
+          "losses" : 0,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 18,
+          "losses" : 6,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 24,
+          "losses" : 13,
+          "ot" : 4,
+          "type" : "home"
+        }, {
+          "wins" : 28,
+          "losses" : 9,
+          "ot" : 4,
+          "type" : "away"
+        }, {
+          "wins" : 2,
+          "losses" : 4,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 7,
+          "losses" : 3,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 30,
+          "losses" : 17,
+          "ot" : 3,
+          "type" : "Eastern"
+        }, {
+          "wins" : 22,
+          "losses" : 5,
+          "ot" : 5,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 3,
+        "name" : "New York Rangers",
+        "link" : "/api/v1/teams/3"
+      },
+      "leagueRecord" : {
+        "wins" : 47,
+        "losses" : 22,
+        "ot" : 13,
+        "type" : "league"
+      },
+      "regulationWins" : 37,
+      "goalsAgainst" : 219,
+      "goalsScored" : 277,
+      "points" : 107,
+      "divisionRank" : "3",
+      "divisionL10Rank" : "2",
+      "divisionRoadRank" : "2",
+      "divisionHomeRank" : "4",
+      "conferenceRank" : "5",
+      "conferenceL10Rank" : "6",
+      "conferenceRoadRank" : "3",
+      "conferenceHomeRank" : "9",
+      "leagueRank" : "9",
+      "leagueL10Rank" : "11",
+      "leagueRoadRank" : "7",
+      "leagueHomeRank" : "15",
+      "wildCardRank" : "0",
+      "row" : 43,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 1,
+        "streakCode" : "L1"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.6524390243902439,
+      "ppDivisionRank" : "3",
+      "ppConferenceRank" : "5",
+      "ppLeagueRank" : "9",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 10,
+          "losses" : 4,
+          "ot" : 2,
+          "type" : "Central"
+        }, {
+          "wins" : 11,
+          "losses" : 7,
+          "ot" : 6,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 11,
+          "losses" : 2,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 15,
+          "losses" : 9,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 23,
+          "losses" : 13,
+          "ot" : 5,
+          "type" : "home"
+        }, {
+          "wins" : 24,
+          "losses" : 9,
+          "ot" : 8,
+          "type" : "away"
+        }, {
+          "wins" : 4,
+          "losses" : 3,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 5,
+          "losses" : 2,
+          "ot" : 3,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 26,
+          "losses" : 16,
+          "ot" : 8,
+          "type" : "Eastern"
+        }, {
+          "wins" : 21,
+          "losses" : 6,
+          "ot" : 5,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 2,
+        "name" : "New York Islanders",
+        "link" : "/api/v1/teams/2"
+      },
+      "leagueRecord" : {
+        "wins" : 42,
+        "losses" : 31,
+        "ot" : 9,
+        "type" : "league"
+      },
+      "regulationWins" : 36,
+      "goalsAgainst" : 222,
+      "goalsScored" : 243,
+      "points" : 93,
+      "divisionRank" : "4",
+      "divisionL10Rank" : "4",
+      "divisionRoadRank" : "5",
+      "divisionHomeRank" : "2",
+      "conferenceRank" : "7",
+      "conferenceL10Rank" : "8",
+      "conferenceRoadRank" : "9",
+      "conferenceHomeRank" : "5",
+      "leagueRank" : "15",
+      "leagueL10Rank" : "18",
+      "leagueRoadRank" : "20",
+      "leagueHomeRank" : "8",
+      "wildCardRank" : "1",
+      "row" : 41,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 1,
+        "streakCode" : "W1"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.5670731707317073,
+      "ppDivisionRank" : "4",
+      "ppConferenceRank" : "7",
+      "ppLeagueRank" : "15",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 6,
+          "losses" : 7,
+          "ot" : 3,
+          "type" : "Central"
+        }, {
+          "wins" : 10,
+          "losses" : 10,
+          "ot" : 4,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 10,
+          "losses" : 6,
+          "ot" : 0,
+          "type" : "Pacific"
+        }, {
+          "wins" : 16,
+          "losses" : 8,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 25,
+          "losses" : 13,
+          "ot" : 3,
+          "type" : "home"
+        }, {
+          "wins" : 17,
+          "losses" : 18,
+          "ot" : 6,
+          "type" : "away"
+        }, {
+          "wins" : 1,
+          "losses" : 5,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 5,
+          "losses" : 4,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 26,
+          "losses" : 18,
+          "ot" : 6,
+          "type" : "Eastern"
+        }, {
+          "wins" : 16,
+          "losses" : 13,
+          "ot" : 3,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 5,
+        "name" : "Pittsburgh Penguins",
+        "link" : "/api/v1/teams/5"
+      },
+      "leagueRecord" : {
+        "wins" : 40,
+        "losses" : 31,
+        "ot" : 11,
+        "type" : "league"
+      },
+      "regulationWins" : 31,
+      "goalsAgainst" : 264,
+      "goalsScored" : 262,
+      "points" : 91,
+      "divisionRank" : "5",
+      "divisionL10Rank" : "3",
+      "divisionRoadRank" : "4",
+      "divisionHomeRank" : "5",
+      "conferenceRank" : "9",
+      "conferenceL10Rank" : "7",
+      "conferenceRoadRank" : "8",
+      "conferenceHomeRank" : "10",
+      "leagueRank" : "19",
+      "leagueL10Rank" : "17",
+      "leagueRoadRank" : "19",
+      "leagueHomeRank" : "16",
+      "wildCardRank" : "3",
+      "row" : 39,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "ot",
+        "streakNumber" : 1,
+        "streakCode" : "OT1"
+      },
+      "pointsPercentage" : 0.5548780487804879,
+      "ppDivisionRank" : "5",
+      "ppConferenceRank" : "9",
+      "ppLeagueRank" : "19",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 13,
+          "losses" : 3,
+          "ot" : 0,
+          "type" : "Central"
+        }, {
+          "wins" : 10,
+          "losses" : 9,
+          "ot" : 5,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 7,
+          "losses" : 9,
+          "ot" : 0,
+          "type" : "Pacific"
+        }, {
+          "wins" : 10,
+          "losses" : 10,
+          "ot" : 6,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 23,
+          "losses" : 13,
+          "ot" : 5,
+          "type" : "home"
+        }, {
+          "wins" : 17,
+          "losses" : 18,
+          "ot" : 6,
+          "type" : "away"
+        }, {
+          "wins" : 1,
+          "losses" : 1,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 5,
+          "losses" : 4,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 20,
+          "losses" : 19,
+          "ot" : 11,
+          "type" : "Eastern"
+        }, {
+          "wins" : 20,
+          "losses" : 12,
+          "ot" : 0,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 15,
+        "name" : "Washington Capitals",
+        "link" : "/api/v1/teams/15"
+      },
+      "leagueRecord" : {
+        "wins" : 35,
+        "losses" : 37,
+        "ot" : 10,
+        "type" : "league"
+      },
+      "regulationWins" : 27,
+      "goalsAgainst" : 265,
+      "goalsScored" : 255,
+      "points" : 80,
+      "divisionRank" : "6",
+      "divisionL10Rank" : "7",
+      "divisionRoadRank" : "6",
+      "divisionHomeRank" : "6",
+      "conferenceRank" : "13",
+      "conferenceL10Rank" : "15",
+      "conferenceRoadRank" : "10",
+      "conferenceHomeRank" : "12",
+      "leagueRank" : "25",
+      "leagueL10Rank" : "28",
+      "leagueRoadRank" : "22",
+      "leagueHomeRank" : "23",
+      "wildCardRank" : "7",
+      "row" : 33,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "ot",
+        "streakNumber" : 1,
+        "streakCode" : "OT1"
+      },
+      "pointsPercentage" : 0.4878048780487805,
+      "ppDivisionRank" : "6",
+      "ppConferenceRank" : "13",
+      "ppLeagueRank" : "25",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 6,
+          "losses" : 9,
+          "ot" : 1,
+          "type" : "Central"
+        }, {
+          "wins" : 8,
+          "losses" : 14,
+          "ot" : 2,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 9,
+          "losses" : 5,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 12,
+          "losses" : 9,
+          "ot" : 5,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 18,
+          "losses" : 16,
+          "ot" : 7,
+          "type" : "home"
+        }, {
+          "wins" : 17,
+          "losses" : 21,
+          "ot" : 3,
+          "type" : "away"
+        }, {
+          "wins" : 2,
+          "losses" : 4,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 2,
+          "losses" : 6,
+          "ot" : 2,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 20,
+          "losses" : 23,
+          "ot" : 7,
+          "type" : "Eastern"
+        }, {
+          "wins" : 15,
+          "losses" : 14,
+          "ot" : 3,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 4,
+        "name" : "Philadelphia Flyers",
+        "link" : "/api/v1/teams/4"
+      },
+      "leagueRecord" : {
+        "wins" : 31,
+        "losses" : 38,
+        "ot" : 13,
+        "type" : "league"
+      },
+      "regulationWins" : 26,
+      "goalsAgainst" : 277,
+      "goalsScored" : 222,
+      "points" : 75,
+      "divisionRank" : "7",
+      "divisionL10Rank" : "6",
+      "divisionRoadRank" : "7",
+      "divisionHomeRank" : "7",
+      "conferenceRank" : "14",
+      "conferenceL10Rank" : "13",
+      "conferenceRoadRank" : "14",
+      "conferenceHomeRank" : "13",
+      "leagueRank" : "26",
+      "leagueL10Rank" : "26",
+      "leagueRoadRank" : "26",
+      "leagueHomeRank" : "25",
+      "wildCardRank" : "8",
+      "row" : 29,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 2,
+        "streakCode" : "W2"
+      },
+      "pointsPercentage" : 0.4573170731707317,
+      "ppDivisionRank" : "7",
+      "ppConferenceRank" : "14",
+      "ppLeagueRank" : "26",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 7,
+          "losses" : 6,
+          "ot" : 3,
+          "type" : "Central"
+        }, {
+          "wins" : 10,
+          "losses" : 12,
+          "ot" : 2,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 7,
+          "losses" : 7,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 7,
+          "losses" : 13,
+          "ot" : 6,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 18,
+          "losses" : 18,
+          "ot" : 5,
+          "type" : "home"
+        }, {
+          "wins" : 13,
+          "losses" : 20,
+          "ot" : 8,
+          "type" : "away"
+        }, {
+          "wins" : 2,
+          "losses" : 1,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 3,
+          "losses" : 6,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 17,
+          "losses" : 25,
+          "ot" : 8,
+          "type" : "Eastern"
+        }, {
+          "wins" : 14,
+          "losses" : 13,
+          "ot" : 5,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 29,
+        "name" : "Columbus Blue Jackets",
+        "link" : "/api/v1/teams/29"
+      },
+      "leagueRecord" : {
+        "wins" : 25,
+        "losses" : 48,
+        "ot" : 9,
+        "type" : "league"
+      },
+      "regulationWins" : 15,
+      "goalsAgainst" : 330,
+      "goalsScored" : 214,
+      "points" : 59,
+      "divisionRank" : "8",
+      "divisionL10Rank" : "8",
+      "divisionRoadRank" : "8",
+      "divisionHomeRank" : "8",
+      "conferenceRank" : "16",
+      "conferenceL10Rank" : "16",
+      "conferenceRoadRank" : "16",
+      "conferenceHomeRank" : "16",
+      "leagueRank" : "31",
+      "leagueL10Rank" : "29",
+      "leagueRoadRank" : "31",
+      "leagueHomeRank" : "29",
+      "wildCardRank" : "10",
+      "row" : 24,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 1,
+        "streakCode" : "L1"
+      },
+      "pointsPercentage" : 0.3597560975609756,
+      "ppDivisionRank" : "8",
+      "ppConferenceRank" : "16",
+      "ppLeagueRank" : "31",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 5,
+          "losses" : 9,
+          "ot" : 2,
+          "type" : "Central"
+        }, {
+          "wins" : 6,
+          "losses" : 17,
+          "ot" : 1,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 7,
+          "losses" : 7,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 7,
+          "losses" : 15,
+          "ot" : 4,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 16,
+          "losses" : 23,
+          "ot" : 2,
+          "type" : "home"
+        }, {
+          "wins" : 9,
+          "losses" : 25,
+          "ot" : 7,
+          "type" : "away"
+        }, {
+          "wins" : 1,
+          "losses" : 1,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 2,
+          "losses" : 6,
+          "ot" : 2,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 13,
+          "losses" : 32,
+          "ot" : 5,
+          "type" : "Eastern"
+        }, {
+          "wins" : 12,
+          "losses" : 16,
+          "ot" : 4,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    } ]
+  }, {
+    "standingsType" : "regularSeason",
+    "league" : {
+      "id" : 133,
+      "name" : "National Hockey League",
+      "link" : "/api/v1/league/133"
+    },
+    "division" : {
+      "id" : 17,
+      "name" : "Atlantic",
+      "nameShort" : "ATL",
+      "link" : "/api/v1/divisions/17",
+      "abbreviation" : "A"
+    },
+    "conference" : {
+      "id" : 6,
+      "name" : "Eastern",
+      "link" : "/api/v1/conferences/6"
+    },
+    "teamRecords" : [ {
+      "team" : {
+        "id" : 6,
+        "name" : "Boston Bruins",
+        "link" : "/api/v1/teams/6"
+      },
+      "leagueRecord" : {
+        "wins" : 65,
+        "losses" : 12,
+        "ot" : 5,
+        "type" : "league"
+      },
+      "regulationWins" : 54,
+      "goalsAgainst" : 177,
+      "goalsScored" : 305,
+      "points" : 135,
+      "divisionRank" : "1",
+      "divisionL10Rank" : "1",
+      "divisionRoadRank" : "1",
+      "divisionHomeRank" : "1",
+      "conferenceRank" : "1",
+      "conferenceL10Rank" : "1",
+      "conferenceRoadRank" : "1",
+      "conferenceHomeRank" : "1",
+      "leagueRank" : "1",
+      "leagueL10Rank" : "2",
+      "leagueRoadRank" : "1",
+      "leagueHomeRank" : "1",
+      "wildCardRank" : "0",
+      "row" : 61,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 8,
+        "streakCode" : "W8"
+      },
+      "clinchIndicator" : "p",
+      "pointsPercentage" : 0.823170731707317,
+      "ppDivisionRank" : "1",
+      "ppConferenceRank" : "1",
+      "ppLeagueRank" : "1",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 13,
+          "losses" : 3,
+          "ot" : 0,
+          "type" : "Central"
+        }, {
+          "wins" : 18,
+          "losses" : 5,
+          "ot" : 3,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 12,
+          "losses" : 2,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 22,
+          "losses" : 2,
+          "ot" : 0,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 34,
+          "losses" : 4,
+          "ot" : 3,
+          "type" : "home"
+        }, {
+          "wins" : 31,
+          "losses" : 8,
+          "ot" : 2,
+          "type" : "away"
+        }, {
+          "wins" : 4,
+          "losses" : 3,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 9,
+          "losses" : 1,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 40,
+          "losses" : 7,
+          "ot" : 3,
+          "type" : "Eastern"
+        }, {
+          "wins" : 25,
+          "losses" : 5,
+          "ot" : 2,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 10,
+        "name" : "Toronto Maple Leafs",
+        "link" : "/api/v1/teams/10"
+      },
+      "leagueRecord" : {
+        "wins" : 50,
+        "losses" : 21,
+        "ot" : 11,
+        "type" : "league"
+      },
+      "regulationWins" : 42,
+      "goalsAgainst" : 222,
+      "goalsScored" : 279,
+      "points" : 111,
+      "divisionRank" : "2",
+      "divisionL10Rank" : "2",
+      "divisionRoadRank" : "3",
+      "divisionHomeRank" : "3",
+      "conferenceRank" : "4",
+      "conferenceL10Rank" : "2",
+      "conferenceRoadRank" : "6",
+      "conferenceHomeRank" : "3",
+      "leagueRank" : "4",
+      "leagueL10Rank" : "5",
+      "leagueRoadRank" : "11",
+      "leagueHomeRank" : "3",
+      "wildCardRank" : "0",
+      "row" : 49,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 4,
+        "streakCode" : "W4"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.676829268292683,
+      "ppDivisionRank" : "2",
+      "ppConferenceRank" : "4",
+      "ppLeagueRank" : "4",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 11,
+          "losses" : 3,
+          "ot" : 2,
+          "type" : "Central"
+        }, {
+          "wins" : 15,
+          "losses" : 7,
+          "ot" : 4,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 8,
+          "losses" : 5,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 16,
+          "losses" : 6,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 27,
+          "losses" : 8,
+          "ot" : 6,
+          "type" : "home"
+        }, {
+          "wins" : 23,
+          "losses" : 13,
+          "ot" : 5,
+          "type" : "away"
+        }, {
+          "wins" : 1,
+          "losses" : 2,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 7,
+          "losses" : 1,
+          "ot" : 2,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 31,
+          "losses" : 13,
+          "ot" : 6,
+          "type" : "Eastern"
+        }, {
+          "wins" : 19,
+          "losses" : 8,
+          "ot" : 5,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 14,
+        "name" : "Tampa Bay Lightning",
+        "link" : "/api/v1/teams/14"
+      },
+      "leagueRecord" : {
+        "wins" : 46,
+        "losses" : 30,
+        "ot" : 6,
+        "type" : "league"
+      },
+      "regulationWins" : 38,
+      "goalsAgainst" : 254,
+      "goalsScored" : 283,
+      "points" : 98,
+      "divisionRank" : "3",
+      "divisionL10Rank" : "7",
+      "divisionRoadRank" : "5",
+      "divisionHomeRank" : "2",
+      "conferenceRank" : "6",
+      "conferenceL10Rank" : "12",
+      "conferenceRoadRank" : "11",
+      "conferenceHomeRank" : "2",
+      "leagueRank" : "13",
+      "leagueL10Rank" : "24",
+      "leagueRoadRank" : "23",
+      "leagueHomeRank" : "2",
+      "wildCardRank" : "0",
+      "row" : 43,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 1,
+        "streakCode" : "W1"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.5975609756097561,
+      "ppDivisionRank" : "3",
+      "ppConferenceRank" : "6",
+      "ppLeagueRank" : "13",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 12,
+          "losses" : 3,
+          "ot" : 1,
+          "type" : "Central"
+        }, {
+          "wins" : 12,
+          "losses" : 13,
+          "ot" : 1,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 9,
+          "losses" : 5,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 13,
+          "losses" : 9,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 28,
+          "losses" : 8,
+          "ot" : 5,
+          "type" : "home"
+        }, {
+          "wins" : 18,
+          "losses" : 22,
+          "ot" : 1,
+          "type" : "away"
+        }, {
+          "wins" : 3,
+          "losses" : 2,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 4,
+          "losses" : 6,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 25,
+          "losses" : 22,
+          "ot" : 3,
+          "type" : "Eastern"
+        }, {
+          "wins" : 21,
+          "losses" : 8,
+          "ot" : 3,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 13,
+        "name" : "Florida Panthers",
+        "link" : "/api/v1/teams/13"
+      },
+      "leagueRecord" : {
+        "wins" : 42,
+        "losses" : 32,
+        "ot" : 8,
+        "type" : "league"
+      },
+      "regulationWins" : 36,
+      "goalsAgainst" : 273,
+      "goalsScored" : 290,
+      "points" : 92,
+      "divisionRank" : "4",
+      "divisionL10Rank" : "4",
+      "divisionRoadRank" : "4",
+      "divisionHomeRank" : "5",
+      "conferenceRank" : "8",
+      "conferenceL10Rank" : "5",
+      "conferenceRoadRank" : "7",
+      "conferenceHomeRank" : "8",
+      "leagueRank" : "17",
+      "leagueL10Rank" : "10",
+      "leagueRoadRank" : "17",
+      "leagueHomeRank" : "13",
+      "wildCardRank" : "2",
+      "row" : 40,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 1,
+        "streakCode" : "L1"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.5609756097560976,
+      "ppDivisionRank" : "4",
+      "ppConferenceRank" : "8",
+      "ppLeagueRank" : "17",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 5,
+          "losses" : 9,
+          "ot" : 2,
+          "type" : "Central"
+        }, {
+          "wins" : 17,
+          "losses" : 6,
+          "ot" : 3,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 8,
+          "losses" : 6,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 12,
+          "losses" : 11,
+          "ot" : 1,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 23,
+          "losses" : 13,
+          "ot" : 5,
+          "type" : "home"
+        }, {
+          "wins" : 19,
+          "losses" : 19,
+          "ot" : 3,
+          "type" : "away"
+        }, {
+          "wins" : 2,
+          "losses" : 1,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 6,
+          "losses" : 3,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 29,
+          "losses" : 17,
+          "ot" : 4,
+          "type" : "Eastern"
+        }, {
+          "wins" : 13,
+          "losses" : 15,
+          "ot" : 4,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 7,
+        "name" : "Buffalo Sabres",
+        "link" : "/api/v1/teams/7"
+      },
+      "leagueRecord" : {
+        "wins" : 42,
+        "losses" : 33,
+        "ot" : 7,
+        "type" : "league"
+      },
+      "regulationWins" : 30,
+      "goalsAgainst" : 300,
+      "goalsScored" : 296,
+      "points" : 91,
+      "divisionRank" : "5",
+      "divisionL10Rank" : "3",
+      "divisionRoadRank" : "2",
+      "divisionHomeRank" : "7",
+      "conferenceRank" : "10",
+      "conferenceL10Rank" : "3",
+      "conferenceRoadRank" : "5",
+      "conferenceHomeRank" : "14",
+      "leagueRank" : "20",
+      "leagueL10Rank" : "7",
+      "leagueRoadRank" : "10",
+      "leagueHomeRank" : "27",
+      "wildCardRank" : "4",
+      "row" : 39,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 2,
+        "streakCode" : "W2"
+      },
+      "pointsPercentage" : 0.5548780487804879,
+      "ppDivisionRank" : "5",
+      "ppConferenceRank" : "10",
+      "ppLeagueRank" : "20",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 9,
+          "losses" : 5,
+          "ot" : 2,
+          "type" : "Central"
+        }, {
+          "wins" : 12,
+          "losses" : 12,
+          "ot" : 2,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 9,
+          "losses" : 7,
+          "ot" : 0,
+          "type" : "Pacific"
+        }, {
+          "wins" : 12,
+          "losses" : 9,
+          "ot" : 3,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 17,
+          "losses" : 20,
+          "ot" : 4,
+          "type" : "home"
+        }, {
+          "wins" : 25,
+          "losses" : 13,
+          "ot" : 3,
+          "type" : "away"
+        }, {
+          "wins" : 3,
+          "losses" : 3,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 7,
+          "losses" : 2,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 24,
+          "losses" : 21,
+          "ot" : 5,
+          "type" : "Eastern"
+        }, {
+          "wins" : 18,
+          "losses" : 12,
+          "ot" : 2,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 9,
+        "name" : "Ottawa Senators",
+        "link" : "/api/v1/teams/9"
+      },
+      "leagueRecord" : {
+        "wins" : 39,
+        "losses" : 35,
+        "ot" : 8,
+        "type" : "league"
+      },
+      "regulationWins" : 31,
+      "goalsAgainst" : 271,
+      "goalsScored" : 261,
+      "points" : 86,
+      "divisionRank" : "6",
+      "divisionL10Rank" : "5",
+      "divisionRoadRank" : "7",
+      "divisionHomeRank" : "4",
+      "conferenceRank" : "11",
+      "conferenceL10Rank" : "9",
+      "conferenceRoadRank" : "13",
+      "conferenceHomeRank" : "7",
+      "leagueRank" : "21",
+      "leagueL10Rank" : "19",
+      "leagueRoadRank" : "25",
+      "leagueHomeRank" : "12",
+      "wildCardRank" : "5",
+      "row" : 37,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "ot",
+        "streakNumber" : 1,
+        "streakCode" : "OT1"
+      },
+      "pointsPercentage" : 0.524390243902439,
+      "ppDivisionRank" : "6",
+      "ppConferenceRank" : "11",
+      "ppLeagueRank" : "21",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 5,
+          "losses" : 9,
+          "ot" : 2,
+          "type" : "Central"
+        }, {
+          "wins" : 15,
+          "losses" : 9,
+          "ot" : 2,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 6,
+          "losses" : 10,
+          "ot" : 0,
+          "type" : "Pacific"
+        }, {
+          "wins" : 13,
+          "losses" : 7,
+          "ot" : 4,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 24,
+          "losses" : 14,
+          "ot" : 3,
+          "type" : "home"
+        }, {
+          "wins" : 15,
+          "losses" : 21,
+          "ot" : 5,
+          "type" : "away"
+        }, {
+          "wins" : 2,
+          "losses" : 1,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 4,
+          "losses" : 3,
+          "ot" : 3,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 28,
+          "losses" : 16,
+          "ot" : 6,
+          "type" : "Eastern"
+        }, {
+          "wins" : 11,
+          "losses" : 19,
+          "ot" : 2,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 17,
+        "name" : "Detroit Red Wings",
+        "link" : "/api/v1/teams/17"
+      },
+      "leagueRecord" : {
+        "wins" : 35,
+        "losses" : 37,
+        "ot" : 10,
+        "type" : "league"
+      },
+      "regulationWins" : 28,
+      "goalsAgainst" : 279,
+      "goalsScored" : 240,
+      "points" : 80,
+      "divisionRank" : "7",
+      "divisionL10Rank" : "6",
+      "divisionRoadRank" : "6",
+      "divisionHomeRank" : "6",
+      "conferenceRank" : "12",
+      "conferenceL10Rank" : "11",
+      "conferenceRoadRank" : "12",
+      "conferenceHomeRank" : "11",
+      "leagueRank" : "24",
+      "leagueL10Rank" : "22",
+      "leagueRoadRank" : "24",
+      "leagueHomeRank" : "22",
+      "wildCardRank" : "6",
+      "row" : 32,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 4,
+        "streakCode" : "L4"
+      },
+      "pointsPercentage" : 0.4878048780487805,
+      "ppDivisionRank" : "7",
+      "ppConferenceRank" : "12",
+      "ppLeagueRank" : "24",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 6,
+          "losses" : 7,
+          "ot" : 3,
+          "type" : "Central"
+        }, {
+          "wins" : 9,
+          "losses" : 14,
+          "ot" : 3,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 9,
+          "losses" : 4,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 11,
+          "losses" : 12,
+          "ot" : 1,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 19,
+          "losses" : 17,
+          "ot" : 5,
+          "type" : "home"
+        }, {
+          "wins" : 16,
+          "losses" : 20,
+          "ot" : 5,
+          "type" : "away"
+        }, {
+          "wins" : 3,
+          "losses" : 4,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 4,
+          "losses" : 5,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 20,
+          "losses" : 26,
+          "ot" : 4,
+          "type" : "Eastern"
+        }, {
+          "wins" : 15,
+          "losses" : 11,
+          "ot" : 6,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 8,
+        "name" : "Montréal Canadiens",
+        "link" : "/api/v1/teams/8"
+      },
+      "leagueRecord" : {
+        "wins" : 31,
+        "losses" : 45,
+        "ot" : 6,
+        "type" : "league"
+      },
+      "regulationWins" : 21,
+      "goalsAgainst" : 307,
+      "goalsScored" : 232,
+      "points" : 68,
+      "divisionRank" : "8",
+      "divisionL10Rank" : "8",
+      "divisionRoadRank" : "8",
+      "divisionHomeRank" : "8",
+      "conferenceRank" : "15",
+      "conferenceL10Rank" : "14",
+      "conferenceRoadRank" : "15",
+      "conferenceHomeRank" : "15",
+      "leagueRank" : "28",
+      "leagueL10Rank" : "27",
+      "leagueRoadRank" : "28",
+      "leagueHomeRank" : "28",
+      "wildCardRank" : "9",
+      "row" : 26,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 3,
+        "streakCode" : "L3"
+      },
+      "pointsPercentage" : 0.4146341463414634,
+      "ppDivisionRank" : "8",
+      "ppConferenceRank" : "15",
+      "ppLeagueRank" : "28",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 8,
+          "losses" : 6,
+          "ot" : 2,
+          "type" : "Central"
+        }, {
+          "wins" : 6,
+          "losses" : 19,
+          "ot" : 1,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 6,
+          "losses" : 9,
+          "ot" : 1,
+          "type" : "Pacific"
+        }, {
+          "wins" : 11,
+          "losses" : 11,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 17,
+          "losses" : 21,
+          "ot" : 3,
+          "type" : "home"
+        }, {
+          "wins" : 14,
+          "losses" : 24,
+          "ot" : 3,
+          "type" : "away"
+        }, {
+          "wins" : 5,
+          "losses" : 2,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 3,
+          "losses" : 7,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 17,
+          "losses" : 30,
+          "ot" : 3,
+          "type" : "Eastern"
+        }, {
+          "wins" : 14,
+          "losses" : 15,
+          "ot" : 3,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    } ]
+  }, {
+    "standingsType" : "regularSeason",
+    "league" : {
+      "id" : 133,
+      "name" : "National Hockey League",
+      "link" : "/api/v1/league/133"
+    },
+    "division" : {
+      "id" : 16,
+      "name" : "Central",
+      "nameShort" : "CEN",
+      "link" : "/api/v1/divisions/16",
+      "abbreviation" : "C"
+    },
+    "conference" : {
+      "id" : 5,
+      "name" : "Western",
+      "link" : "/api/v1/conferences/5"
+    },
+    "teamRecords" : [ {
+      "team" : {
+        "id" : 21,
+        "name" : "Colorado Avalanche",
+        "link" : "/api/v1/teams/21"
+      },
+      "leagueRecord" : {
+        "wins" : 51,
+        "losses" : 24,
+        "ot" : 7,
+        "type" : "league"
+      },
+      "regulationWins" : 36,
+      "goalsAgainst" : 226,
+      "goalsScored" : 280,
+      "points" : 109,
+      "divisionRank" : "1",
+      "divisionL10Rank" : "1",
+      "divisionRoadRank" : "1",
+      "divisionHomeRank" : "4",
+      "conferenceRank" : "3",
+      "conferenceL10Rank" : "2",
+      "conferenceRoadRank" : "2",
+      "conferenceHomeRank" : "7",
+      "leagueRank" : "7",
+      "leagueL10Rank" : "3",
+      "leagueRoadRank" : "4",
+      "leagueHomeRank" : "17",
+      "wildCardRank" : "0",
+      "row" : 45,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 2,
+        "streakCode" : "W2"
+      },
+      "clinchIndicator" : "y",
+      "pointsPercentage" : 0.6646341463414634,
+      "ppDivisionRank" : "1",
+      "ppConferenceRank" : "3",
+      "ppLeagueRank" : "7",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 19,
+          "losses" : 6,
+          "ot" : 1,
+          "type" : "Central"
+        }, {
+          "wins" : 9,
+          "losses" : 6,
+          "ot" : 1,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 14,
+          "losses" : 7,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 9,
+          "losses" : 5,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 22,
+          "losses" : 13,
+          "ot" : 6,
+          "type" : "home"
+        }, {
+          "wins" : 29,
+          "losses" : 11,
+          "ot" : 1,
+          "type" : "away"
+        }, {
+          "wins" : 6,
+          "losses" : 3,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 8,
+          "losses" : 1,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 18,
+          "losses" : 11,
+          "ot" : 3,
+          "type" : "Eastern"
+        }, {
+          "wins" : 33,
+          "losses" : 13,
+          "ot" : 4,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 25,
+        "name" : "Dallas Stars",
+        "link" : "/api/v1/teams/25"
+      },
+      "leagueRecord" : {
+        "wins" : 47,
+        "losses" : 21,
+        "ot" : 14,
+        "type" : "league"
+      },
+      "regulationWins" : 39,
+      "goalsAgainst" : 218,
+      "goalsScored" : 285,
+      "points" : 108,
+      "divisionRank" : "2",
+      "divisionL10Rank" : "2",
+      "divisionRoadRank" : "2",
+      "divisionHomeRank" : "3",
+      "conferenceRank" : "4",
+      "conferenceL10Rank" : "3",
+      "conferenceRoadRank" : "5",
+      "conferenceHomeRank" : "4",
+      "leagueRank" : "8",
+      "leagueL10Rank" : "4",
+      "leagueRoadRank" : "8",
+      "leagueHomeRank" : "9",
+      "wildCardRank" : "0",
+      "row" : 43,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 6,
+        "streakCode" : "W6"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.6585365853658537,
+      "ppDivisionRank" : "2",
+      "ppConferenceRank" : "4",
+      "ppLeagueRank" : "8",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 18,
+          "losses" : 4,
+          "ot" : 4,
+          "type" : "Central"
+        }, {
+          "wins" : 8,
+          "losses" : 4,
+          "ot" : 4,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 12,
+          "losses" : 10,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 9,
+          "losses" : 3,
+          "ot" : 4,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 22,
+          "losses" : 10,
+          "ot" : 9,
+          "type" : "home"
+        }, {
+          "wins" : 25,
+          "losses" : 11,
+          "ot" : 5,
+          "type" : "away"
+        }, {
+          "wins" : 4,
+          "losses" : 3,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 8,
+          "losses" : 2,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 17,
+          "losses" : 7,
+          "ot" : 8,
+          "type" : "Eastern"
+        }, {
+          "wins" : 30,
+          "losses" : 14,
+          "ot" : 6,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 30,
+        "name" : "Minnesota Wild",
+        "link" : "/api/v1/teams/30"
+      },
+      "leagueRecord" : {
+        "wins" : 46,
+        "losses" : 25,
+        "ot" : 11,
+        "type" : "league"
+      },
+      "regulationWins" : 34,
+      "goalsAgainst" : 225,
+      "goalsScored" : 246,
+      "points" : 103,
+      "divisionRank" : "3",
+      "divisionL10Rank" : "4",
+      "divisionRoadRank" : "3",
+      "divisionHomeRank" : "2",
+      "conferenceRank" : "6",
+      "conferenceL10Rank" : "8",
+      "conferenceRoadRank" : "6",
+      "conferenceHomeRank" : "3",
+      "leagueRank" : "11",
+      "leagueL10Rank" : "14",
+      "leagueRoadRank" : "12",
+      "leagueHomeRank" : "7",
+      "wildCardRank" : "0",
+      "row" : 39,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "ot",
+        "streakNumber" : 1,
+        "streakCode" : "OT1"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.6280487804878049,
+      "ppDivisionRank" : "3",
+      "ppConferenceRank" : "6",
+      "ppLeagueRank" : "11",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 16,
+          "losses" : 8,
+          "ot" : 2,
+          "type" : "Central"
+        }, {
+          "wins" : 7,
+          "losses" : 5,
+          "ot" : 4,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 13,
+          "losses" : 8,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 10,
+          "losses" : 4,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 25,
+          "losses" : 12,
+          "ot" : 4,
+          "type" : "home"
+        }, {
+          "wins" : 21,
+          "losses" : 13,
+          "ot" : 7,
+          "type" : "away"
+        }, {
+          "wins" : 7,
+          "losses" : 6,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 5,
+          "losses" : 3,
+          "ot" : 2,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 17,
+          "losses" : 9,
+          "ot" : 6,
+          "type" : "Eastern"
+        }, {
+          "wins" : 29,
+          "losses" : 16,
+          "ot" : 5,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 52,
+        "name" : "Winnipeg Jets",
+        "link" : "/api/v1/teams/52"
+      },
+      "leagueRecord" : {
+        "wins" : 46,
+        "losses" : 33,
+        "ot" : 3,
+        "type" : "league"
+      },
+      "regulationWins" : 36,
+      "goalsAgainst" : 225,
+      "goalsScored" : 247,
+      "points" : 95,
+      "divisionRank" : "4",
+      "divisionL10Rank" : "3",
+      "divisionRoadRank" : "5",
+      "divisionHomeRank" : "1",
+      "conferenceRank" : "8",
+      "conferenceL10Rank" : "7",
+      "conferenceRoadRank" : "11",
+      "conferenceHomeRank" : "2",
+      "leagueRank" : "14",
+      "leagueL10Rank" : "13",
+      "leagueRoadRank" : "18",
+      "leagueHomeRank" : "6",
+      "wildCardRank" : "2",
+      "row" : 45,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 1,
+        "streakCode" : "L1"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.5792682926829268,
+      "ppDivisionRank" : "4",
+      "ppConferenceRank" : "8",
+      "ppLeagueRank" : "14",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 18,
+          "losses" : 8,
+          "ot" : 0,
+          "type" : "Central"
+        }, {
+          "wins" : 9,
+          "losses" : 7,
+          "ot" : 0,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 13,
+          "losses" : 8,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 6,
+          "losses" : 10,
+          "ot" : 0,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 26,
+          "losses" : 13,
+          "ot" : 2,
+          "type" : "home"
+        }, {
+          "wins" : 20,
+          "losses" : 20,
+          "ot" : 1,
+          "type" : "away"
+        }, {
+          "wins" : 1,
+          "losses" : 1,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 6,
+          "losses" : 4,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 15,
+          "losses" : 17,
+          "ot" : 0,
+          "type" : "Eastern"
+        }, {
+          "wins" : 31,
+          "losses" : 16,
+          "ot" : 3,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 18,
+        "name" : "Nashville Predators",
+        "link" : "/api/v1/teams/18"
+      },
+      "leagueRecord" : {
+        "wins" : 42,
+        "losses" : 32,
+        "ot" : 8,
+        "type" : "league"
+      },
+      "regulationWins" : 29,
+      "goalsAgainst" : 238,
+      "goalsScored" : 229,
+      "points" : 92,
+      "divisionRank" : "5",
+      "divisionL10Rank" : "5",
+      "divisionRoadRank" : "4",
+      "divisionHomeRank" : "5",
+      "conferenceRank" : "10",
+      "conferenceL10Rank" : "9",
+      "conferenceRoadRank" : "9",
+      "conferenceHomeRank" : "8",
+      "leagueRank" : "18",
+      "leagueL10Rank" : "15",
+      "leagueRoadRank" : "15",
+      "leagueHomeRank" : "18",
+      "wildCardRank" : "4",
+      "row" : 36,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 1,
+        "streakCode" : "L1"
+      },
+      "pointsPercentage" : 0.5609756097560976,
+      "ppDivisionRank" : "5",
+      "ppConferenceRank" : "10",
+      "ppLeagueRank" : "18",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 9,
+          "losses" : 13,
+          "ot" : 4,
+          "type" : "Central"
+        }, {
+          "wins" : 7,
+          "losses" : 8,
+          "ot" : 1,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 16,
+          "losses" : 5,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 10,
+          "losses" : 6,
+          "ot" : 0,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 22,
+          "losses" : 15,
+          "ot" : 4,
+          "type" : "home"
+        }, {
+          "wins" : 20,
+          "losses" : 17,
+          "ot" : 4,
+          "type" : "away"
+        }, {
+          "wins" : 6,
+          "losses" : 2,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 6,
+          "losses" : 4,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 17,
+          "losses" : 14,
+          "ot" : 1,
+          "type" : "Eastern"
+        }, {
+          "wins" : 25,
+          "losses" : 18,
+          "ot" : 7,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 19,
+        "name" : "St. Louis Blues",
+        "link" : "/api/v1/teams/19"
+      },
+      "leagueRecord" : {
+        "wins" : 37,
+        "losses" : 38,
+        "ot" : 7,
+        "type" : "league"
+      },
+      "regulationWins" : 27,
+      "goalsAgainst" : 301,
+      "goalsScored" : 263,
+      "points" : 81,
+      "divisionRank" : "6",
+      "divisionL10Rank" : "6",
+      "divisionRoadRank" : "6",
+      "divisionHomeRank" : "7",
+      "conferenceRank" : "12",
+      "conferenceL10Rank" : "12",
+      "conferenceRoadRank" : "12",
+      "conferenceHomeRank" : "12",
+      "leagueRank" : "23",
+      "leagueL10Rank" : "23",
+      "leagueRoadRank" : "21",
+      "leagueHomeRank" : "24",
+      "wildCardRank" : "6",
+      "row" : 34,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 3,
+        "streakCode" : "L3"
+      },
+      "pointsPercentage" : 0.49390243902439024,
+      "ppDivisionRank" : "6",
+      "ppConferenceRank" : "12",
+      "ppLeagueRank" : "23",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 9,
+          "losses" : 16,
+          "ot" : 1,
+          "type" : "Central"
+        }, {
+          "wins" : 5,
+          "losses" : 8,
+          "ot" : 3,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 14,
+          "losses" : 8,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 9,
+          "losses" : 6,
+          "ot" : 1,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 18,
+          "losses" : 17,
+          "ot" : 6,
+          "type" : "home"
+        }, {
+          "wins" : 19,
+          "losses" : 21,
+          "ot" : 1,
+          "type" : "away"
+        }, {
+          "wins" : 3,
+          "losses" : 3,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 4,
+          "losses" : 5,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 14,
+          "losses" : 14,
+          "ot" : 4,
+          "type" : "Eastern"
+        }, {
+          "wins" : 23,
+          "losses" : 24,
+          "ot" : 3,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 53,
+        "name" : "Arizona Coyotes",
+        "link" : "/api/v1/teams/53"
+      },
+      "leagueRecord" : {
+        "wins" : 28,
+        "losses" : 40,
+        "ot" : 14,
+        "type" : "league"
+      },
+      "regulationWins" : 20,
+      "goalsAgainst" : 299,
+      "goalsScored" : 228,
+      "points" : 70,
+      "divisionRank" : "7",
+      "divisionL10Rank" : "8",
+      "divisionRoadRank" : "8",
+      "divisionHomeRank" : "6",
+      "conferenceRank" : "13",
+      "conferenceL10Rank" : "15",
+      "conferenceRoadRank" : "16",
+      "conferenceHomeRank" : "9",
+      "leagueRank" : "27",
+      "leagueL10Rank" : "31",
+      "leagueRoadRank" : "32",
+      "leagueHomeRank" : "19",
+      "wildCardRank" : "7",
+      "row" : 25,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "ot",
+        "streakNumber" : 1,
+        "streakCode" : "OT1"
+      },
+      "pointsPercentage" : 0.4268292682926829,
+      "ppDivisionRank" : "7",
+      "ppConferenceRank" : "13",
+      "ppLeagueRank" : "27",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 9,
+          "losses" : 11,
+          "ot" : 6,
+          "type" : "Central"
+        }, {
+          "wins" : 7,
+          "losses" : 7,
+          "ot" : 2,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 5,
+          "losses" : 14,
+          "ot" : 5,
+          "type" : "Pacific"
+        }, {
+          "wins" : 7,
+          "losses" : 8,
+          "ot" : 1,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 21,
+          "losses" : 15,
+          "ot" : 5,
+          "type" : "home"
+        }, {
+          "wins" : 7,
+          "losses" : 25,
+          "ot" : 9,
+          "type" : "away"
+        }, {
+          "wins" : 3,
+          "losses" : 4,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 1,
+          "losses" : 7,
+          "ot" : 2,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 14,
+          "losses" : 15,
+          "ot" : 3,
+          "type" : "Eastern"
+        }, {
+          "wins" : 14,
+          "losses" : 25,
+          "ot" : 11,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 16,
+        "name" : "Chicago Blackhawks",
+        "link" : "/api/v1/teams/16"
+      },
+      "leagueRecord" : {
+        "wins" : 26,
+        "losses" : 49,
+        "ot" : 7,
+        "type" : "league"
+      },
+      "regulationWins" : 18,
+      "goalsAgainst" : 301,
+      "goalsScored" : 204,
+      "points" : 59,
+      "divisionRank" : "8",
+      "divisionL10Rank" : "7",
+      "divisionRoadRank" : "7",
+      "divisionHomeRank" : "8",
+      "conferenceRank" : "15",
+      "conferenceL10Rank" : "14",
+      "conferenceRoadRank" : "15",
+      "conferenceHomeRank" : "14",
+      "leagueRank" : "30",
+      "leagueL10Rank" : "30",
+      "leagueRoadRank" : "30",
+      "leagueHomeRank" : "30",
+      "wildCardRank" : "9",
+      "row" : 24,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "ot",
+        "streakNumber" : 1,
+        "streakCode" : "OT1"
+      },
+      "pointsPercentage" : 0.3597560975609756,
+      "ppDivisionRank" : "8",
+      "ppConferenceRank" : "15",
+      "ppLeagueRank" : "30",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 6,
+          "losses" : 19,
+          "ot" : 1,
+          "type" : "Central"
+        }, {
+          "wins" : 7,
+          "losses" : 6,
+          "ot" : 3,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 9,
+          "losses" : 13,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 4,
+          "losses" : 11,
+          "ot" : 1,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 14,
+          "losses" : 23,
+          "ot" : 4,
+          "type" : "home"
+        }, {
+          "wins" : 12,
+          "losses" : 26,
+          "ot" : 3,
+          "type" : "away"
+        }, {
+          "wins" : 2,
+          "losses" : 2,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 2,
+          "losses" : 7,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 11,
+          "losses" : 17,
+          "ot" : 4,
+          "type" : "Eastern"
+        }, {
+          "wins" : 15,
+          "losses" : 32,
+          "ot" : 3,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    } ]
+  }, {
+    "standingsType" : "regularSeason",
+    "league" : {
+      "id" : 133,
+      "name" : "National Hockey League",
+      "link" : "/api/v1/league/133"
+    },
+    "division" : {
+      "id" : 15,
+      "name" : "Pacific",
+      "nameShort" : "PAC",
+      "link" : "/api/v1/divisions/15",
+      "abbreviation" : "P"
+    },
+    "conference" : {
+      "id" : 5,
+      "name" : "Western",
+      "link" : "/api/v1/conferences/5"
+    },
+    "teamRecords" : [ {
+      "team" : {
+        "id" : 54,
+        "name" : "Vegas Golden Knights",
+        "link" : "/api/v1/teams/54"
+      },
+      "leagueRecord" : {
+        "wins" : 51,
+        "losses" : 22,
+        "ot" : 9,
+        "type" : "league"
+      },
+      "regulationWins" : 38,
+      "goalsAgainst" : 229,
+      "goalsScored" : 272,
+      "points" : 111,
+      "divisionRank" : "1",
+      "divisionL10Rank" : "2",
+      "divisionRoadRank" : "1",
+      "divisionHomeRank" : "3",
+      "conferenceRank" : "1",
+      "conferenceL10Rank" : "4",
+      "conferenceRoadRank" : "1",
+      "conferenceHomeRank" : "6",
+      "leagueRank" : "5",
+      "leagueL10Rank" : "6",
+      "leagueRoadRank" : "3",
+      "leagueHomeRank" : "14",
+      "wildCardRank" : "0",
+      "row" : 46,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 2,
+        "streakCode" : "W2"
+      },
+      "clinchIndicator" : "z",
+      "pointsPercentage" : 0.676829268292683,
+      "ppDivisionRank" : "1",
+      "ppConferenceRank" : "1",
+      "ppLeagueRank" : "5",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 15,
+          "losses" : 5,
+          "ot" : 4,
+          "type" : "Central"
+        }, {
+          "wins" : 12,
+          "losses" : 4,
+          "ot" : 0,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 14,
+          "losses" : 9,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 10,
+          "losses" : 4,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 25,
+          "losses" : 15,
+          "ot" : 1,
+          "type" : "home"
+        }, {
+          "wins" : 26,
+          "losses" : 7,
+          "ot" : 8,
+          "type" : "away"
+        }, {
+          "wins" : 5,
+          "losses" : 4,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 6,
+          "losses" : 1,
+          "ot" : 3,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 22,
+          "losses" : 8,
+          "ot" : 2,
+          "type" : "Eastern"
+        }, {
+          "wins" : 29,
+          "losses" : 14,
+          "ot" : 7,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 22,
+        "name" : "Edmonton Oilers",
+        "link" : "/api/v1/teams/22"
+      },
+      "leagueRecord" : {
+        "wins" : 50,
+        "losses" : 23,
+        "ot" : 9,
+        "type" : "league"
+      },
+      "regulationWins" : 45,
+      "goalsAgainst" : 260,
+      "goalsScored" : 325,
+      "points" : 109,
+      "divisionRank" : "2",
+      "divisionL10Rank" : "1",
+      "divisionRoadRank" : "2",
+      "divisionHomeRank" : "2",
+      "conferenceRank" : "2",
+      "conferenceL10Rank" : "1",
+      "conferenceRoadRank" : "3",
+      "conferenceHomeRank" : "5",
+      "leagueRank" : "6",
+      "leagueL10Rank" : "1",
+      "leagueRoadRank" : "5",
+      "leagueHomeRank" : "10",
+      "wildCardRank" : "0",
+      "row" : 50,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 9,
+        "streakCode" : "W9"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.6646341463414634,
+      "ppDivisionRank" : "2",
+      "ppConferenceRank" : "2",
+      "ppLeagueRank" : "6",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 14,
+          "losses" : 6,
+          "ot" : 4,
+          "type" : "Central"
+        }, {
+          "wins" : 11,
+          "losses" : 4,
+          "ot" : 1,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 19,
+          "losses" : 6,
+          "ot" : 1,
+          "type" : "Pacific"
+        }, {
+          "wins" : 6,
+          "losses" : 7,
+          "ot" : 3,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 23,
+          "losses" : 12,
+          "ot" : 6,
+          "type" : "home"
+        }, {
+          "wins" : 27,
+          "losses" : 11,
+          "ot" : 3,
+          "type" : "away"
+        }, {
+          "wins" : 0,
+          "losses" : 4,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 9,
+          "losses" : 0,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 17,
+          "losses" : 11,
+          "ot" : 4,
+          "type" : "Eastern"
+        }, {
+          "wins" : 33,
+          "losses" : 12,
+          "ot" : 5,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 26,
+        "name" : "Los Angeles Kings",
+        "link" : "/api/v1/teams/26"
+      },
+      "leagueRecord" : {
+        "wins" : 47,
+        "losses" : 25,
+        "ot" : 10,
+        "type" : "league"
+      },
+      "regulationWins" : 37,
+      "goalsAgainst" : 257,
+      "goalsScored" : 280,
+      "points" : 104,
+      "divisionRank" : "3",
+      "divisionL10Rank" : "6",
+      "divisionRoadRank" : "4",
+      "divisionHomeRank" : "1",
+      "conferenceRank" : "5",
+      "conferenceL10Rank" : "11",
+      "conferenceRoadRank" : "7",
+      "conferenceHomeRank" : "1",
+      "leagueRank" : "10",
+      "leagueL10Rank" : "20",
+      "leagueRoadRank" : "13",
+      "leagueHomeRank" : "5",
+      "wildCardRank" : "0",
+      "row" : 41,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 2,
+        "streakCode" : "W2"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.6341463414634146,
+      "ppDivisionRank" : "3",
+      "ppConferenceRank" : "5",
+      "ppLeagueRank" : "10",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 15,
+          "losses" : 6,
+          "ot" : 3,
+          "type" : "Central"
+        }, {
+          "wins" : 11,
+          "losses" : 4,
+          "ot" : 1,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 15,
+          "losses" : 8,
+          "ot" : 3,
+          "type" : "Pacific"
+        }, {
+          "wins" : 6,
+          "losses" : 7,
+          "ot" : 3,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 26,
+          "losses" : 11,
+          "ot" : 4,
+          "type" : "home"
+        }, {
+          "wins" : 21,
+          "losses" : 14,
+          "ot" : 6,
+          "type" : "away"
+        }, {
+          "wins" : 6,
+          "losses" : 3,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 5,
+          "losses" : 5,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 17,
+          "losses" : 11,
+          "ot" : 4,
+          "type" : "Eastern"
+        }, {
+          "wins" : 30,
+          "losses" : 14,
+          "ot" : 6,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 55,
+        "name" : "Seattle Kraken",
+        "link" : "/api/v1/teams/55"
+      },
+      "leagueRecord" : {
+        "wins" : 46,
+        "losses" : 28,
+        "ot" : 8,
+        "type" : "league"
+      },
+      "regulationWins" : 37,
+      "goalsAgainst" : 256,
+      "goalsScored" : 289,
+      "points" : 100,
+      "divisionRank" : "4",
+      "divisionL10Rank" : "4",
+      "divisionRoadRank" : "3",
+      "divisionHomeRank" : "5",
+      "conferenceRank" : "7",
+      "conferenceL10Rank" : "6",
+      "conferenceRoadRank" : "4",
+      "conferenceHomeRank" : "11",
+      "leagueRank" : "12",
+      "leagueL10Rank" : "12",
+      "leagueRoadRank" : "6",
+      "leagueHomeRank" : "21",
+      "wildCardRank" : "1",
+      "row" : 46,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 2,
+        "streakCode" : "L2"
+      },
+      "clinchIndicator" : "x",
+      "pointsPercentage" : 0.6097560975609756,
+      "ppDivisionRank" : "4",
+      "ppConferenceRank" : "7",
+      "ppLeagueRank" : "12",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 14,
+          "losses" : 4,
+          "ot" : 6,
+          "type" : "Central"
+        }, {
+          "wins" : 9,
+          "losses" : 7,
+          "ot" : 0,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 13,
+          "losses" : 11,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 10,
+          "losses" : 6,
+          "ot" : 0,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 20,
+          "losses" : 17,
+          "ot" : 4,
+          "type" : "home"
+        }, {
+          "wins" : 26,
+          "losses" : 11,
+          "ot" : 4,
+          "type" : "away"
+        }, {
+          "wins" : 0,
+          "losses" : 4,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 6,
+          "losses" : 4,
+          "ot" : 0,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 19,
+          "losses" : 13,
+          "ot" : 0,
+          "type" : "Eastern"
+        }, {
+          "wins" : 27,
+          "losses" : 15,
+          "ot" : 8,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 20,
+        "name" : "Calgary Flames",
+        "link" : "/api/v1/teams/20"
+      },
+      "leagueRecord" : {
+        "wins" : 38,
+        "losses" : 27,
+        "ot" : 17,
+        "type" : "league"
+      },
+      "regulationWins" : 31,
+      "goalsAgainst" : 252,
+      "goalsScored" : 260,
+      "points" : 93,
+      "divisionRank" : "5",
+      "divisionL10Rank" : "3",
+      "divisionRoadRank" : "5",
+      "divisionHomeRank" : "4",
+      "conferenceRank" : "9",
+      "conferenceL10Rank" : "5",
+      "conferenceRoadRank" : "8",
+      "conferenceHomeRank" : "10",
+      "leagueRank" : "16",
+      "leagueL10Rank" : "9",
+      "leagueRoadRank" : "14",
+      "leagueHomeRank" : "20",
+      "wildCardRank" : "3",
+      "row" : 36,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 1,
+        "streakCode" : "W1"
+      },
+      "pointsPercentage" : 0.5670731707317073,
+      "ppDivisionRank" : "5",
+      "ppConferenceRank" : "9",
+      "ppLeagueRank" : "16",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 10,
+          "losses" : 9,
+          "ot" : 5,
+          "type" : "Central"
+        }, {
+          "wins" : 5,
+          "losses" : 7,
+          "ot" : 4,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 16,
+          "losses" : 6,
+          "ot" : 4,
+          "type" : "Pacific"
+        }, {
+          "wins" : 7,
+          "losses" : 5,
+          "ot" : 4,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 20,
+          "losses" : 16,
+          "ot" : 5,
+          "type" : "home"
+        }, {
+          "wins" : 18,
+          "losses" : 11,
+          "ot" : 12,
+          "type" : "away"
+        }, {
+          "wins" : 2,
+          "losses" : 5,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 6,
+          "losses" : 2,
+          "ot" : 2,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 12,
+          "losses" : 12,
+          "ot" : 8,
+          "type" : "Eastern"
+        }, {
+          "wins" : 26,
+          "losses" : 15,
+          "ot" : 9,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 23,
+        "name" : "Vancouver Canucks",
+        "link" : "/api/v1/teams/23"
+      },
+      "leagueRecord" : {
+        "wins" : 38,
+        "losses" : 37,
+        "ot" : 7,
+        "type" : "league"
+      },
+      "regulationWins" : 24,
+      "goalsAgainst" : 298,
+      "goalsScored" : 276,
+      "points" : 83,
+      "divisionRank" : "6",
+      "divisionL10Rank" : "5",
+      "divisionRoadRank" : "6",
+      "divisionHomeRank" : "6",
+      "conferenceRank" : "11",
+      "conferenceL10Rank" : "10",
+      "conferenceRoadRank" : "10",
+      "conferenceHomeRank" : "13",
+      "leagueRank" : "22",
+      "leagueL10Rank" : "16",
+      "leagueRoadRank" : "16",
+      "leagueHomeRank" : "26",
+      "wildCardRank" : "5",
+      "row" : 32,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "wins",
+        "streakNumber" : 2,
+        "streakCode" : "W2"
+      },
+      "pointsPercentage" : 0.5060975609756098,
+      "ppDivisionRank" : "6",
+      "ppConferenceRank" : "11",
+      "ppLeagueRank" : "22",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 12,
+          "losses" : 8,
+          "ot" : 4,
+          "type" : "Central"
+        }, {
+          "wins" : 5,
+          "losses" : 11,
+          "ot" : 0,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 16,
+          "losses" : 9,
+          "ot" : 1,
+          "type" : "Pacific"
+        }, {
+          "wins" : 5,
+          "losses" : 9,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 19,
+          "losses" : 20,
+          "ot" : 2,
+          "type" : "home"
+        }, {
+          "wins" : 19,
+          "losses" : 17,
+          "ot" : 5,
+          "type" : "away"
+        }, {
+          "wins" : 6,
+          "losses" : 2,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 5,
+          "losses" : 3,
+          "ot" : 2,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 10,
+          "losses" : 20,
+          "ot" : 2,
+          "type" : "Eastern"
+        }, {
+          "wins" : 28,
+          "losses" : 17,
+          "ot" : 5,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 28,
+        "name" : "San Jose Sharks",
+        "link" : "/api/v1/teams/28"
+      },
+      "leagueRecord" : {
+        "wins" : 22,
+        "losses" : 44,
+        "ot" : 16,
+        "type" : "league"
+      },
+      "regulationWins" : 16,
+      "goalsAgainst" : 321,
+      "goalsScored" : 234,
+      "points" : 60,
+      "divisionRank" : "7",
+      "divisionL10Rank" : "7",
+      "divisionRoadRank" : "7",
+      "divisionHomeRank" : "8",
+      "conferenceRank" : "14",
+      "conferenceL10Rank" : "13",
+      "conferenceRoadRank" : "13",
+      "conferenceHomeRank" : "16",
+      "leagueRank" : "29",
+      "leagueL10Rank" : "25",
+      "leagueRoadRank" : "27",
+      "leagueHomeRank" : "32",
+      "wildCardRank" : "8",
+      "row" : 21,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 5,
+        "streakCode" : "L5"
+      },
+      "pointsPercentage" : 0.36585365853658536,
+      "ppDivisionRank" : "7",
+      "ppConferenceRank" : "14",
+      "ppLeagueRank" : "29",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 10,
+          "losses" : 12,
+          "ot" : 2,
+          "type" : "Central"
+        }, {
+          "wins" : 4,
+          "losses" : 10,
+          "ot" : 2,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 4,
+          "losses" : 14,
+          "ot" : 8,
+          "type" : "Pacific"
+        }, {
+          "wins" : 4,
+          "losses" : 8,
+          "ot" : 4,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 8,
+          "losses" : 22,
+          "ot" : 11,
+          "type" : "home"
+        }, {
+          "wins" : 14,
+          "losses" : 22,
+          "ot" : 5,
+          "type" : "away"
+        }, {
+          "wins" : 1,
+          "losses" : 6,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 3,
+          "losses" : 6,
+          "ot" : 1,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 8,
+          "losses" : 18,
+          "ot" : 6,
+          "type" : "Eastern"
+        }, {
+          "wins" : 14,
+          "losses" : 26,
+          "ot" : 10,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    }, {
+      "team" : {
+        "id" : 24,
+        "name" : "Anaheim Ducks",
+        "link" : "/api/v1/teams/24"
+      },
+      "leagueRecord" : {
+        "wins" : 23,
+        "losses" : 47,
+        "ot" : 12,
+        "type" : "league"
+      },
+      "regulationWins" : 13,
+      "goalsAgainst" : 338,
+      "goalsScored" : 209,
+      "points" : 58,
+      "divisionRank" : "8",
+      "divisionL10Rank" : "8",
+      "divisionRoadRank" : "8",
+      "divisionHomeRank" : "7",
+      "conferenceRank" : "16",
+      "conferenceL10Rank" : "16",
+      "conferenceRoadRank" : "14",
+      "conferenceHomeRank" : "15",
+      "leagueRank" : "32",
+      "leagueL10Rank" : "32",
+      "leagueRoadRank" : "29",
+      "leagueHomeRank" : "31",
+      "wildCardRank" : "10",
+      "row" : 20,
+      "gamesPlayed" : 82,
+      "streak" : {
+        "streakType" : "losses",
+        "streakNumber" : 2,
+        "streakCode" : "L2"
+      },
+      "pointsPercentage" : 0.35365853658536583,
+      "ppDivisionRank" : "8",
+      "ppConferenceRank" : "16",
+      "ppLeagueRank" : "32",
+      "records" : {
+        "divisionRecords" : [ {
+          "wins" : 6,
+          "losses" : 12,
+          "ot" : 6,
+          "type" : "Central"
+        }, {
+          "wins" : 4,
+          "losses" : 10,
+          "ot" : 2,
+          "type" : "Atlantic"
+        }, {
+          "wins" : 7,
+          "losses" : 17,
+          "ot" : 2,
+          "type" : "Pacific"
+        }, {
+          "wins" : 6,
+          "losses" : 8,
+          "ot" : 2,
+          "type" : "Metropolitan"
+        } ],
+        "overallRecords" : [ {
+          "wins" : 12,
+          "losses" : 25,
+          "ot" : 4,
+          "type" : "home"
+        }, {
+          "wins" : 11,
+          "losses" : 22,
+          "ot" : 8,
+          "type" : "away"
+        }, {
+          "wins" : 3,
+          "losses" : 3,
+          "type" : "shootOuts"
+        }, {
+          "wins" : 0,
+          "losses" : 8,
+          "ot" : 2,
+          "type" : "lastTen"
+        } ],
+        "conferenceRecords" : [ {
+          "wins" : 10,
+          "losses" : 18,
+          "ot" : 4,
+          "type" : "Eastern"
+        }, {
+          "wins" : 13,
+          "losses" : 29,
+          "ot" : 8,
+          "type" : "Western"
+        } ]
+      },
+      "lastUpdated" : "2023-10-15T05:46:51Z"
+    } ]
+  } ]
+}

--- a/test/hockey-discord_test.coffee
+++ b/test/hockey-discord_test.coffee
@@ -61,3 +61,61 @@ describe 'hubot-hockey for discord', ->
       return
     , 1000)
 
+
+  it 'responds with division leader standings', (done) ->
+    Date.now = () ->
+      Date.parse('Wed Feb 1 12:10:00 CDT 2023')
+    nock('https://statsapi.web.nhl.com')
+      .get('/api/v1/standings')
+      .query({
+        date: '2023-02-01',
+        expand: 'standings.record'
+      })
+      .delay({
+        head: 100,
+        body: 200,
+      })
+      .replyWithFile(200, __dirname + '/fixtures/nhl-statsapi-standings.json')
+
+    selfRoom = @room
+    selfRoom.user.say('alice', '@hubot nhl')
+    setTimeout(() ->
+      try
+        expect(selfRoom.messages).to.eql [
+          ['alice', '@hubot nhl']
+          ['hubot', "```.--------------------------------------------------------.\n|                    Division Leaders                    |\n|--------------------------------------------------------|\n|         Team         | GP | W  | L  | OT | PTS |  L10  |\n|----------------------|----|----|----|----|-----|-------|\n| Carolina Hurricanes  | 82 | 52 | 21 |  9 | 113 | 5-5-0 |\n| Boston Bruins        | 82 | 65 | 12 |  5 | 135 | 9-1-0 |\n| Colorado Avalanche   | 82 | 51 | 24 |  7 | 109 | 8-1-1 |\n| Vegas Golden Knights | 82 | 51 | 22 |  9 | 111 | 6-1-3 |\n'--------------------------------------------------------'```"]
+        ]
+        done()
+      catch err
+        done err
+      return
+    , 1000)
+
+  it 'responds with division standings', (done) ->
+    Date.now = () ->
+      Date.parse('Wed Feb 1 12:10:00 CDT 2023')
+    nock('https://statsapi.web.nhl.com')
+      .get('/api/v1/standings')
+      .query({
+        date: '2023-02-01',
+        expand: 'standings.record'
+      })
+      .delay({
+        head: 100,
+        body: 200,
+      })
+      .replyWithFile(200, __dirname + '/fixtures/nhl-statsapi-standings.json')
+
+    selfRoom = @room
+    selfRoom.user.say('alice', '@hubot nhl central')
+    setTimeout(() ->
+      try
+        expect(selfRoom.messages).to.eql [
+          ['alice', '@hubot nhl central']
+          ['hubot', "```.-------------------------------------------------------.\n|                      C Standings                      |\n|-------------------------------------------------------|\n|        Team         | GP | W  | L  | OT | PTS |  L10  |\n|---------------------|----|----|----|----|-----|-------|\n| Colorado Avalanche  | 82 | 51 | 24 |  7 | 109 | 8-1-1 |\n| Dallas Stars        | 82 | 47 | 21 | 14 | 108 | 8-2-0 |\n| Minnesota Wild      | 82 | 46 | 25 | 11 | 103 | 5-3-2 |\n| Winnipeg Jets       | 82 | 46 | 33 |  3 |  95 | 6-4-0 |\n| Nashville Predators | 82 | 42 | 32 |  8 |  92 | 6-4-0 |\n| St. Louis Blues     | 82 | 37 | 38 |  7 |  81 | 4-5-1 |\n| Arizona Coyotes     | 82 | 28 | 40 | 14 |  70 | 1-7-2 |\n| Chicago Blackhawks  | 82 | 26 | 49 |  7 |  59 | 2-7-1 |\n'-------------------------------------------------------'```"]
+        ]
+        done()
+      catch err
+        done err
+      return
+    , 1000)

--- a/test/hockey-slack_test.coffee
+++ b/test/hockey-slack_test.coffee
@@ -510,3 +510,62 @@ describe 'hubot-hockey for slack', ->
         done err
       return
     , 1000)
+
+
+  it 'responds with division leader standings', (done) ->
+    Date.now = () ->
+      Date.parse('Wed Feb 1 12:10:00 CDT 2023')
+    nock('https://statsapi.web.nhl.com')
+      .get('/api/v1/standings')
+      .query({
+        date: '2023-02-01',
+        expand: 'standings.record'
+      })
+      .delay({
+        head: 100,
+        body: 200,
+      })
+      .replyWithFile(200, __dirname + '/fixtures/nhl-statsapi-standings.json')
+
+    selfRoom = @room
+    selfRoom.user.say('alice', '@hubot nhl')
+    setTimeout(() ->
+      try
+        expect(selfRoom.messages).to.eql [
+          ['alice', '@hubot nhl']
+          ['hubot', "```.--------------------------------------------------------.\n|                    Division Leaders                    |\n|--------------------------------------------------------|\n|         Team         | GP | W  | L  | OT | PTS |  L10  |\n|----------------------|----|----|----|----|-----|-------|\n| Carolina Hurricanes  | 82 | 52 | 21 |  9 | 113 | 5-5-0 |\n| Boston Bruins        | 82 | 65 | 12 |  5 | 135 | 9-1-0 |\n| Colorado Avalanche   | 82 | 51 | 24 |  7 | 109 | 8-1-1 |\n| Vegas Golden Knights | 82 | 51 | 22 |  9 | 111 | 6-1-3 |\n'--------------------------------------------------------'```"]
+        ]
+        done()
+      catch err
+        done err
+      return
+    , 1000)
+
+  it 'responds with division standings', (done) ->
+    Date.now = () ->
+      Date.parse('Wed Feb 1 12:10:00 CDT 2023')
+    nock('https://statsapi.web.nhl.com')
+      .get('/api/v1/standings')
+      .query({
+        date: '2023-02-01',
+        expand: 'standings.record'
+      })
+      .delay({
+        head: 100,
+        body: 200,
+      })
+      .replyWithFile(200, __dirname + '/fixtures/nhl-statsapi-standings.json')
+
+    selfRoom = @room
+    selfRoom.user.say('alice', '@hubot nhl central')
+    setTimeout(() ->
+      try
+        expect(selfRoom.messages).to.eql [
+          ['alice', '@hubot nhl central']
+          ['hubot', "```.-------------------------------------------------------.\n|                      C Standings                      |\n|-------------------------------------------------------|\n|        Team         | GP | W  | L  | OT | PTS |  L10  |\n|---------------------|----|----|----|----|-----|-------|\n| Colorado Avalanche  | 82 | 51 | 24 |  7 | 109 | 8-1-1 |\n| Dallas Stars        | 82 | 47 | 21 | 14 | 108 | 8-2-0 |\n| Minnesota Wild      | 82 | 46 | 25 | 11 | 103 | 5-3-2 |\n| Winnipeg Jets       | 82 | 46 | 33 |  3 |  95 | 6-4-0 |\n| Nashville Predators | 82 | 42 | 32 |  8 |  92 | 6-4-0 |\n| St. Louis Blues     | 82 | 37 | 38 |  7 |  81 | 4-5-1 |\n| Arizona Coyotes     | 82 | 28 | 40 | 14 |  70 | 1-7-2 |\n| Chicago Blackhawks  | 82 | 26 | 49 |  7 |  59 | 2-7-1 |\n'-------------------------------------------------------'```"]
+        ]
+        done()
+      catch err
+        done err
+      return
+    , 1000)

--- a/test/hockey_test.coffee
+++ b/test/hockey_test.coffee
@@ -253,3 +253,61 @@ describe 'hubot-hockey', ->
         done err
       return
     , 1000)
+
+  it 'responds with division leader standings', (done) ->
+    Date.now = () ->
+      Date.parse('Wed Feb 1 12:10:00 CDT 2023')
+    nock('https://statsapi.web.nhl.com')
+      .get('/api/v1/standings')
+      .query({
+        date: '2023-02-01',
+        expand: 'standings.record'
+      })
+      .delay({
+        head: 100,
+        body: 200,
+      })
+      .replyWithFile(200, __dirname + '/fixtures/nhl-statsapi-standings.json')
+
+    selfRoom = @room
+    selfRoom.user.say('alice', '@hubot nhl')
+    setTimeout(() ->
+      try
+        expect(selfRoom.messages).to.eql [
+          ['alice', '@hubot nhl']
+          ['hubot', ".--------------------------------------------------------.\n|                    Division Leaders                    |\n|--------------------------------------------------------|\n|         Team         | GP | W  | L  | OT | PTS |  L10  |\n|----------------------|----|----|----|----|-----|-------|\n| Carolina Hurricanes  | 82 | 52 | 21 |  9 | 113 | 5-5-0 |\n| Boston Bruins        | 82 | 65 | 12 |  5 | 135 | 9-1-0 |\n| Colorado Avalanche   | 82 | 51 | 24 |  7 | 109 | 8-1-1 |\n| Vegas Golden Knights | 82 | 51 | 22 |  9 | 111 | 6-1-3 |\n'--------------------------------------------------------'"]
+        ]
+        done()
+      catch err
+        done err
+      return
+    , 1000)
+
+  it 'responds with division standings', (done) ->
+    Date.now = () ->
+      Date.parse('Wed Feb 1 12:10:00 CDT 2023')
+    nock('https://statsapi.web.nhl.com')
+      .get('/api/v1/standings')
+      .query({
+        date: '2023-02-01',
+        expand: 'standings.record'
+      })
+      .delay({
+        head: 100,
+        body: 200,
+      })
+      .replyWithFile(200, __dirname + '/fixtures/nhl-statsapi-standings.json')
+
+    selfRoom = @room
+    selfRoom.user.say('alice', '@hubot nhl central')
+    setTimeout(() ->
+      try
+        expect(selfRoom.messages).to.eql [
+          ['alice', '@hubot nhl central']
+          ['hubot', ".-------------------------------------------------------.\n|                      C Standings                      |\n|-------------------------------------------------------|\n|        Team         | GP | W  | L  | OT | PTS |  L10  |\n|---------------------|----|----|----|----|-----|-------|\n| Colorado Avalanche  | 82 | 51 | 24 |  7 | 109 | 8-1-1 |\n| Dallas Stars        | 82 | 47 | 21 | 14 | 108 | 8-2-0 |\n| Minnesota Wild      | 82 | 46 | 25 | 11 | 103 | 5-3-2 |\n| Winnipeg Jets       | 82 | 46 | 33 |  3 |  95 | 6-4-0 |\n| Nashville Predators | 82 | 42 | 32 |  8 |  92 | 6-4-0 |\n| St. Louis Blues     | 82 | 37 | 38 |  7 |  81 | 4-5-1 |\n| Arizona Coyotes     | 82 | 28 | 40 | 14 |  70 | 1-7-2 |\n| Chicago Blackhawks  | 82 | 26 | 49 |  7 |  59 | 2-7-1 |\n'-------------------------------------------------------'"]
+        ]
+        done()
+      catch err
+        done err
+      return
+    , 1000)


### PR DESCRIPTION

```
User> hubot nhl
Hubot> .--------------------------------------------------------.
|                    Division Leaders                    |
|--------------------------------------------------------|
|                      | GP | W  | L  | OT | PTS |  L10  |
|----------------------|----|----|----|----|-----|-------|
| Carolina Hurricanes  | 82 | 52 | 21 |  9 | 113 | 5-5-0 |
| Boston Bruins        | 82 | 65 | 12 |  5 | 135 | 9-1-0 |
| Colorado Avalanche   | 82 | 51 | 24 |  7 | 109 | 8-1-1 |
| Vegas Golden Knights | 82 | 51 | 22 |  9 | 111 | 6-1-3 |
'--------------------------------------------------------'
```
