### PR TITLE
Add extended standings option

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   env: {
     browser: true,
-    es2021: true
+    es2021: true,
   },
   extends: 'airbnb-base',
   overrides: [

--- a/README.md
+++ b/README.md
@@ -4,9 +4,17 @@
 
 Get the game results and the latest NHL playoff odds for the selected team from the very useful [MoneyPuck.com](https://moneypuck.com/).
 
-## Suggested Setup
+## Configuration
 
-There is no additional configuration if you simply wish to get the latest game results and playoff odds.
+There is no additional configuration necessary if you simply wish to get the latest game results and playoff odds.
+
+| Environment Variable | Required? | Description |
+| -------------------- | :-------: | ----------- |
+| `HUBOT_HOCKEY_EXT_STANDINGS` | No | Adds columns to the standings table. See notes below. |
+| `HUBOT_HOCKEY_HIDE_ODDS` | No | Skips show the odds from MoneyPuck |
+
+* By default, the standings table will show Games Played, Wins, Losses, Overtime Losses, and Points.
+* Setting `HUBOT_HOCKEY_EXT_STANDINGS` to any truth-y value will add Points Percentage, Last 10, and Streak.
 
 ## Adding to Your Hubot
 
@@ -18,4 +26,5 @@ See full instructions [here](https://github.com/github/hubot/blob/master/docs/sc
 ## Commands
 
 - `hubot <team>` - Show your team's current playoff odds and next game
-- `hubot nhl [division]` - Show division leaders or division standings
+- `hubot nhl` - Show division leaders
+- `hubot nhl [division|conference]` - Show division or conference standings

--- a/src/hockey.js
+++ b/src/hockey.js
@@ -3,6 +3,7 @@
 //
 // Configuration:
 //   HUBOT_HOCKEY_EXT_STANDINGS - Show extended standings columns
+//   HUBOT_HOCKEY_HIDE_ODDS - Hide playoff odds
 //
 // Commands:
 //   hubot <team or city> - Get the latest game results

--- a/test/hockey-discord_test.js
+++ b/test/hockey-discord_test.js
@@ -53,8 +53,21 @@ describe('hubot-hockey for discord', () => {
         try {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot preds'],
-            ['hubot', '11/7/2023 - Scotiabank Saddledome; TV: BSSO (A) | SNW (H)```  Nashville Predators   2  \n  Calgary Flames        3  ```09:04 3rd - https://www.nhl.com/gamecenter/2023020186'],
-            ['hubot', '__**MoneyPuck.com**__\n**Make Playoffs:** 67.5%\n**Win Stanley Cup:** 4.2%'],
+            [
+              'hubot',
+              '11/7/2023 - Scotiabank Saddledome; TV: BSSO (A) | SNW (H)\n'
+              + '```\n'
+              + '  Nashville Predators   2  \n'
+              + '  Calgary Flames        3  \n'
+              + '```\n'
+              + '09:04 3rd - https://www.nhl.com/gamecenter/2023020186',
+            ],
+            [
+              'hubot',
+              '__**MoneyPuck.com**__\n'
+              + '**Make Playoffs:** 67.5%\n'
+              + '**Win Stanley Cup:** 4.2%',
+            ],
           ]);
           done();
         } catch (err) {
@@ -82,7 +95,21 @@ describe('hubot-hockey for discord', () => {
         try {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot nhl'],
-            ['hubot', "```\n.-------------------------------------------------------.\n|                   Division Leaders                    |\n|-------------------------------------------------------|\n|         Team         | GP | W  | L | OT | PTS |  L10  |\n|----------------------|----|----|---|----|-----|-------|\n| Vegas Golden Knights | 13 | 11 | 1 |  1 |  23 | 8-1-1 |\n| Boston Bruins        | 12 | 10 | 1 |  1 |  21 | 8-1-1 |\n| New York Rangers     | 12 |  9 | 2 |  1 |  19 | 8-1-1 |\n| Dallas Stars         | 11 |  7 | 3 |  1 |  15 | 6-3-1 |\n'-------------------------------------------------------'\n```"],
+            [
+              'hubot',
+              '```\n'
+              + '.-----------------------------------------------.\n'
+              + '|               Division Leaders                |\n'
+              + '|-----------------------------------------------|\n'
+              + '|         Team         | GP | W  | L | OT | PTS |\n'
+              + '|----------------------|----|----|---|----|-----|\n'
+              + '| Vegas Golden Knights | 13 | 11 | 1 |  1 |  23 |\n'
+              + '| Boston Bruins        | 12 | 10 | 1 |  1 |  21 |\n'
+              + '| New York Rangers     | 12 |  9 | 2 |  1 |  19 |\n'
+              + '| Dallas Stars         | 11 |  7 | 3 |  1 |  15 |\n'
+              + "'-----------------------------------------------'\n"
+              + '```',
+            ],
           ]);
           done();
         } catch (err) {
@@ -110,7 +137,25 @@ describe('hubot-hockey for discord', () => {
         try {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot nhl central'],
-            ['hubot', "```\n.-----------------------------------------------------.\n|                  Central Standings                  |\n|-----------------------------------------------------|\n|        Team         | GP | W | L | OT | PTS |  L10  |\n|---------------------|----|---|---|----|-----|-------|\n| Dallas Stars        | 11 | 7 | 3 |  1 |  15 | 6-3-1 |\n| Colorado Avalanche  | 10 | 7 | 3 |  0 |  14 | 7-3-0 |\n| Winnipeg Jets       | 12 | 6 | 4 |  2 |  14 | 5-3-2 |\n| Minnesota Wild      | 12 | 5 | 5 |  2 |  12 | 4-4-2 |\n| Arizona Coyotes     | 11 | 5 | 5 |  1 |  11 | 4-5-1 |\n| St. Louis Blues     | 11 | 5 | 5 |  1 |  11 | 5-5-0 |\n| Nashville Predators | 11 | 5 | 6 |  0 |  10 | 5-5-0 |\n| Chicago Blackhawks  | 11 | 4 | 7 |  0 |   8 | 3-7-0 |\n'-----------------------------------------------------'\n```"],
+            [
+              'hubot',
+              '```\n'
+              + '.---------------------------------------------.\n'
+              + '|         Central Division Standings          |\n'
+              + '|---------------------------------------------|\n'
+              + '|        Team         | GP | W | L | OT | PTS |\n'
+              + '|---------------------|----|---|---|----|-----|\n'
+              + '| Dallas Stars        | 11 | 7 | 3 |  1 |  15 |\n'
+              + '| Colorado Avalanche  | 10 | 7 | 3 |  0 |  14 |\n'
+              + '| Winnipeg Jets       | 12 | 6 | 4 |  2 |  14 |\n'
+              + '| Minnesota Wild      | 12 | 5 | 5 |  2 |  12 |\n'
+              + '| Arizona Coyotes     | 11 | 5 | 5 |  1 |  11 |\n'
+              + '| St. Louis Blues     | 11 | 5 | 5 |  1 |  11 |\n'
+              + '| Nashville Predators | 11 | 5 | 6 |  0 |  10 |\n'
+              + '| Chicago Blackhawks  | 11 | 4 | 7 |  0 |   8 |\n'
+              + "'---------------------------------------------'\n"
+              + '```',
+            ],
           ]);
           done();
         } catch (err) {

--- a/test/hockey-slack_test.js
+++ b/test/hockey-slack_test.js
@@ -68,7 +68,11 @@ describe('hubot-hockey for slack', () => {
                       'text',
                       'pretext',
                     ],
-                    text: '```\n  Nashville Predators   2  \n  Calgary Flames        3  \n```',
+                    text:
+                    '```\n'
+                     + '  Nashville Predators   2  \n'
+                     + '  Calgary Flames        3  \n'
+                     + '```',
                     title: '11/7/2023 - 09:04 3rd',
                     title_link: 'https://www.nhl.com/gamecenter/2023020186',
                   },
@@ -147,7 +151,11 @@ describe('hubot-hockey for slack', () => {
                     'text',
                     'pretext',
                   ],
-                  text: '```\n  Washington Capitals   0  \n  Nashville Predators   1  \n```',
+                  text:
+                    '```\n'
+                    + '  Washington Capitals   0  \n'
+                    + '  Nashville Predators   1  \n'
+                    + '```',
                   title: '12/16/2023 - 07:21 1st Intermission',
                   title_link: 'https://www.nhl.com/gamecenter/2023020468',
                 },
@@ -227,7 +235,11 @@ describe('hubot-hockey for slack', () => {
                       'text',
                       'pretext',
                     ],
-                    text: '```\n  Nashville Predators (5-7-0)  \n  Winnipeg Jets (6-4-2)        \n```',
+                    text:
+                      '```\n'
+                       + '  Nashville Predators (5-7-0)  \n'
+                       + '  Winnipeg Jets (6-4-2)        \n'
+                       + '```',
                     title: '11/9/2023 - 7:00 pm CST',
                     title_link: 'https://www.nhl.com/gamecenter/2023020200',
                   },
@@ -308,7 +320,11 @@ describe('hubot-hockey for slack', () => {
                       'text',
                       'pretext',
                     ],
-                    text: '```\n  Nashville Predators   2  \n  Calgary Flames        4  \n```',
+                    text:
+                    '```\n'
+                     + '  Nashville Predators   2  \n'
+                     + '  Calgary Flames        4  \n'
+                     + '```',
                     title: '11/7/2023 - Final',
                     title_link: 'https://www.nhl.com/gamecenter/2023020186',
                   },
@@ -389,7 +405,11 @@ describe('hubot-hockey for slack', () => {
                       'text',
                       'pretext',
                     ],
-                    text: '```\n  Colorado Avalanche (11-5-0)   \n  Nashville Predators (6-10-0)  \n```',
+                    text:
+                      '```\n'
+                       + '  Colorado Avalanche (11-5-0)   \n'
+                       + '  Nashville Predators (6-10-0)  \n'
+                       + '```',
                     title: '11/20/2023 - 7:00 pm CST',
                     title_link: 'https://www.nhl.com/gamecenter/2023020275',
                   },
@@ -451,7 +471,21 @@ describe('hubot-hockey for slack', () => {
         try {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot nhl'],
-            ['hubot', "```\n.-------------------------------------------------------.\n|                   Division Leaders                    |\n|-------------------------------------------------------|\n|         Team         | GP | W  | L | OT | PTS |  L10  |\n|----------------------|----|----|---|----|-----|-------|\n| Vegas Golden Knights | 13 | 11 | 1 |  1 |  23 | 8-1-1 |\n| Boston Bruins        | 12 | 10 | 1 |  1 |  21 | 8-1-1 |\n| New York Rangers     | 12 |  9 | 2 |  1 |  19 | 8-1-1 |\n| Dallas Stars         | 11 |  7 | 3 |  1 |  15 | 6-3-1 |\n'-------------------------------------------------------'\n```"],
+            [
+              'hubot',
+              '```\n'
+              + '.-----------------------------------------------.\n'
+              + '|               Division Leaders                |\n'
+              + '|-----------------------------------------------|\n'
+              + '|         Team         | GP | W  | L | OT | PTS |\n'
+              + '|----------------------|----|----|---|----|-----|\n'
+              + '| Vegas Golden Knights | 13 | 11 | 1 |  1 |  23 |\n'
+              + '| Boston Bruins        | 12 | 10 | 1 |  1 |  21 |\n'
+              + '| New York Rangers     | 12 |  9 | 2 |  1 |  19 |\n'
+              + '| Dallas Stars         | 11 |  7 | 3 |  1 |  15 |\n'
+              + "'-----------------------------------------------'\n"
+              + '```',
+            ],
           ]);
           done();
         } catch (err) {
@@ -479,7 +513,25 @@ describe('hubot-hockey for slack', () => {
         try {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot nhl central'],
-            ['hubot', "```\n.-----------------------------------------------------.\n|                  Central Standings                  |\n|-----------------------------------------------------|\n|        Team         | GP | W | L | OT | PTS |  L10  |\n|---------------------|----|---|---|----|-----|-------|\n| Dallas Stars        | 11 | 7 | 3 |  1 |  15 | 6-3-1 |\n| Colorado Avalanche  | 10 | 7 | 3 |  0 |  14 | 7-3-0 |\n| Winnipeg Jets       | 12 | 6 | 4 |  2 |  14 | 5-3-2 |\n| Minnesota Wild      | 12 | 5 | 5 |  2 |  12 | 4-4-2 |\n| Arizona Coyotes     | 11 | 5 | 5 |  1 |  11 | 4-5-1 |\n| St. Louis Blues     | 11 | 5 | 5 |  1 |  11 | 5-5-0 |\n| Nashville Predators | 11 | 5 | 6 |  0 |  10 | 5-5-0 |\n| Chicago Blackhawks  | 11 | 4 | 7 |  0 |   8 | 3-7-0 |\n'-----------------------------------------------------'\n```"],
+            [
+              'hubot',
+              '```\n'
+              + '.---------------------------------------------.\n'
+              + '|         Central Division Standings          |\n'
+              + '|---------------------------------------------|\n'
+              + '|        Team         | GP | W | L | OT | PTS |\n'
+              + '|---------------------|----|---|---|----|-----|\n'
+              + '| Dallas Stars        | 11 | 7 | 3 |  1 |  15 |\n'
+              + '| Colorado Avalanche  | 10 | 7 | 3 |  0 |  14 |\n'
+              + '| Winnipeg Jets       | 12 | 6 | 4 |  2 |  14 |\n'
+              + '| Minnesota Wild      | 12 | 5 | 5 |  2 |  12 |\n'
+              + '| Arizona Coyotes     | 11 | 5 | 5 |  1 |  11 |\n'
+              + '| St. Louis Blues     | 11 | 5 | 5 |  1 |  11 |\n'
+              + '| Nashville Predators | 11 | 5 | 6 |  0 |  10 |\n'
+              + '| Chicago Blackhawks  | 11 | 4 | 7 |  0 |   8 |\n'
+              + "'---------------------------------------------'\n"
+              + '```',
+            ],
           ]);
           done();
         } catch (err) {

--- a/test/hockey_test.js
+++ b/test/hockey_test.js
@@ -52,7 +52,11 @@ describe('hubot-hockey', () => {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot preds'],
             ['hubot', '11/7/2023 - Scotiabank Saddledome; TV: BSSO (A) | SNW (H)'],
-            ['hubot', '  Nashville Predators   2  \n  Calgary Flames        3  '],
+            [
+              'hubot',
+              '  Nashville Predators   2  \n'
+              + '  Calgary Flames        3  ',
+            ],
             ['hubot', '09:04 3rd - https://www.nhl.com/gamecenter/2023020186'],
             ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%'],
           ]);
@@ -87,7 +91,11 @@ describe('hubot-hockey', () => {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot preds'],
             ['hubot', '12/16/2023 - Bridgestone Arena; TV: NHLN (N) | BSSO (H) | MNMT (A)'],
-            ['hubot', '  Washington Capitals   0  \n  Nashville Predators   1  '],
+            [
+              'hubot',
+              '  Washington Capitals   0  \n'
+              + '  Nashville Predators   1  ',
+            ],
             ['hubot', '07:21 1st Intermission - https://www.nhl.com/gamecenter/2023020468'],
             ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%'],
           ]);
@@ -122,7 +130,11 @@ describe('hubot-hockey', () => {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot preds'],
             ['hubot', '11/9/2023 - Canada Life Centre; TV: BSSO (A) | TSN3 (H)'],
-            ['hubot', '  Nashville Predators (5-7-0)  \n  Winnipeg Jets (6-4-2)        '],
+            [
+              'hubot',
+              '  Nashville Predators (5-7-0)  \n'
+              + '  Winnipeg Jets (6-4-2)        ',
+            ],
             ['hubot', '7:00 pm CST - https://www.nhl.com/gamecenter/2023020200'],
             ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%'],
           ]);
@@ -157,7 +169,11 @@ describe('hubot-hockey', () => {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot preds'],
             ['hubot', '11/7/2023 - Scotiabank Saddledome'],
-            ['hubot', '  Nashville Predators   2  \n  Calgary Flames        4  '],
+            [
+              'hubot',
+              '  Nashville Predators   2  \n'
+              + '  Calgary Flames        4  ',
+            ],
             ['hubot', 'Final - https://www.nhl.com/gamecenter/2023020186'],
             ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%'],
           ]);
@@ -192,7 +208,11 @@ describe('hubot-hockey', () => {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot preds'],
             ['hubot', '11/20/2023 - Bridgestone Arena; TV: BSSO (H) | ALT (A)'],
-            ['hubot', '  Colorado Avalanche (11-5-0)   \n  Nashville Predators (6-10-0)  '],
+            [
+              'hubot',
+              '  Colorado Avalanche (11-5-0)   \n'
+              + '  Nashville Predators (6-10-0)  ',
+            ],
             ['hubot', '7:00 pm CST - https://www.nhl.com/gamecenter/2023020275'],
             ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%'],
           ]);
@@ -227,7 +247,11 @@ describe('hubot-hockey', () => {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot preds'],
             ['hubot', '12/15/2023 - PNC Arena; TV: ESPN+ (N) | HULU (N)'],
-            ['hubot', '  Nashville Predators   6  \n  Carolina Hurricanes   5  '],
+            [
+              'hubot',
+              '  Nashville Predators   6  \n'
+              + '  Carolina Hurricanes   5  ',
+            ],
             ['hubot', '04:25 OT - https://www.nhl.com/gamecenter/2023020455'],
             ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%'],
           ]);
@@ -262,7 +286,11 @@ describe('hubot-hockey', () => {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot preds'],
             ['hubot', '11/22/2023 - Bridgestone Arena'],
-            ['hubot', '  Calgary Flames        2  \n  Nashville Predators   4  '],
+            [
+              'hubot',
+              '  Calgary Flames        2  \n'
+              + '  Nashville Predators   4  ',
+            ],
             ['hubot', 'Final - https://www.nhl.com/gamecenter/2023020288'],
             ['hubot', 'Odds to Make Playoffs: 67.5% / Win Stanley Cup: 4.2%'],
           ]);
@@ -297,7 +325,11 @@ describe('hubot-hockey', () => {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot bruins'],
             ['hubot', '12/15/2023 - UBS Arena'],
-            ['hubot', '  Boston Bruins        5  \n  New York Islanders   4  '],
+            [
+              'hubot',
+              '  Boston Bruins        5  \n'
+              + '  New York Islanders   4  ',
+            ],
             ['hubot', 'Final/SO - https://www.nhl.com/gamecenter/2023020457'],
             ['hubot', 'Odds to Make Playoffs: 62.0% / Win Stanley Cup: 3.8%'],
           ]);
@@ -327,7 +359,19 @@ describe('hubot-hockey', () => {
         try {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot nhl'],
-            ['hubot', ".-------------------------------------------------------.\n|                   Division Leaders                    |\n|-------------------------------------------------------|\n|         Team         | GP | W  | L | OT | PTS |  L10  |\n|----------------------|----|----|---|----|-----|-------|\n| Vegas Golden Knights | 13 | 11 | 1 |  1 |  23 | 8-1-1 |\n| Boston Bruins        | 12 | 10 | 1 |  1 |  21 | 8-1-1 |\n| New York Rangers     | 12 |  9 | 2 |  1 |  19 | 8-1-1 |\n| Dallas Stars         | 11 |  7 | 3 |  1 |  15 | 6-3-1 |\n'-------------------------------------------------------'"],
+            [
+              'hubot',
+              '.-----------------------------------------------.\n'
+              + '|               Division Leaders                |\n'
+              + '|-----------------------------------------------|\n'
+              + '|         Team         | GP | W  | L | OT | PTS |\n'
+              + '|----------------------|----|----|---|----|-----|\n'
+              + '| Vegas Golden Knights | 13 | 11 | 1 |  1 |  23 |\n'
+              + '| Boston Bruins        | 12 | 10 | 1 |  1 |  21 |\n'
+              + '| New York Rangers     | 12 |  9 | 2 |  1 |  19 |\n'
+              + '| Dallas Stars         | 11 |  7 | 3 |  1 |  15 |\n'
+              + "'-----------------------------------------------'",
+            ],
           ]);
           done();
         } catch (err) {
@@ -355,7 +399,193 @@ describe('hubot-hockey', () => {
         try {
           expect(selfRoom.messages).to.eql([
             ['alice', '@hubot nhl central'],
-            ['hubot', ".-----------------------------------------------------.\n|                  Central Standings                  |\n|-----------------------------------------------------|\n|        Team         | GP | W | L | OT | PTS |  L10  |\n|---------------------|----|---|---|----|-----|-------|\n| Dallas Stars        | 11 | 7 | 3 |  1 |  15 | 6-3-1 |\n| Colorado Avalanche  | 10 | 7 | 3 |  0 |  14 | 7-3-0 |\n| Winnipeg Jets       | 12 | 6 | 4 |  2 |  14 | 5-3-2 |\n| Minnesota Wild      | 12 | 5 | 5 |  2 |  12 | 4-4-2 |\n| Arizona Coyotes     | 11 | 5 | 5 |  1 |  11 | 4-5-1 |\n| St. Louis Blues     | 11 | 5 | 5 |  1 |  11 | 5-5-0 |\n| Nashville Predators | 11 | 5 | 6 |  0 |  10 | 5-5-0 |\n| Chicago Blackhawks  | 11 | 4 | 7 |  0 |   8 | 3-7-0 |\n'-----------------------------------------------------'"],
+            [
+              'hubot',
+              '.---------------------------------------------.\n'
+              + '|         Central Division Standings          |\n'
+              + '|---------------------------------------------|\n'
+              + '|        Team         | GP | W | L | OT | PTS |\n'
+              + '|---------------------|----|---|---|----|-----|\n'
+              + '| Dallas Stars        | 11 | 7 | 3 |  1 |  15 |\n'
+              + '| Colorado Avalanche  | 10 | 7 | 3 |  0 |  14 |\n'
+              + '| Winnipeg Jets       | 12 | 6 | 4 |  2 |  14 |\n'
+              + '| Minnesota Wild      | 12 | 5 | 5 |  2 |  12 |\n'
+              + '| Arizona Coyotes     | 11 | 5 | 5 |  1 |  11 |\n'
+              + '| St. Louis Blues     | 11 | 5 | 5 |  1 |  11 |\n'
+              + '| Nashville Predators | 11 | 5 | 6 |  0 |  10 |\n'
+              + '| Chicago Blackhawks  | 11 | 4 | 7 |  0 |   8 |\n'
+              + "'---------------------------------------------'",
+            ],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      500,
+    );
+  });
+
+  it('responds with conference standings', (done) => {
+    Date.now = () => Date.parse('Tues Nov 7 22:36:00 CST 2023');
+    nock('https://api-web.nhle.com')
+      .get('/v1/standings/2023-11-07')
+      .delay({
+        head: 100,
+        body: 200,
+      })
+      .replyWithFile(200, `${__dirname}/fixtures/api-web-nhle-standings.json`);
+
+    const selfRoom = room;
+    selfRoom.user.say('alice', '@hubot nhl west');
+    setTimeout(
+      () => {
+        try {
+          expect(selfRoom.messages).to.eql([
+            ['alice', '@hubot nhl west'],
+            [
+              'hubot',
+              '.------------------------------------------------.\n'
+              + '|          Western Conference Standings          |\n'
+              + '|------------------------------------------------|\n'
+              + '|         Team         | GP | W  | L  | OT | PTS |\n'
+              + '|----------------------|----|----|----|----|-----|\n'
+              + '| Vegas Golden Knights | 13 | 11 |  1 |  1 |  23 |\n'
+              + '| Vancouver Canucks    | 12 |  9 |  2 |  1 |  19 |\n'
+              + '| Los Angeles Kings    | 11 |  7 |  2 |  2 |  16 |\n'
+              + '| Dallas Stars         | 11 |  7 |  3 |  1 |  15 |\n'
+              + '| Colorado Avalanche   | 10 |  7 |  3 |  0 |  14 |\n'
+              + '| Anaheim Ducks        | 11 |  7 |  4 |  0 |  14 |\n'
+              + '| Winnipeg Jets        | 12 |  6 |  4 |  2 |  14 |\n'
+              + '| Minnesota Wild       | 12 |  5 |  5 |  2 |  12 |\n'
+              + '| Arizona Coyotes      | 11 |  5 |  5 |  1 |  11 |\n'
+              + '| St. Louis Blues      | 11 |  5 |  5 |  1 |  11 |\n'
+              + '| Nashville Predators  | 11 |  5 |  6 |  0 |  10 |\n'
+              + '| Seattle Kraken       | 12 |  4 |  6 |  2 |  10 |\n'
+              + '| Chicago Blackhawks   | 11 |  4 |  7 |  0 |   8 |\n'
+              + '| Calgary Flames       | 11 |  3 |  7 |  1 |   7 |\n'
+              + '| Edmonton Oilers      | 11 |  2 |  8 |  1 |   5 |\n'
+              + '| San Jose Sharks      | 11 |  0 | 10 |  1 |   1 |\n'
+              + "'------------------------------------------------'",
+            ],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      500,
+    );
+  });
+});
+
+describe('hubot-hockey HUBOT_HOCKEY_EXT_STANDINGS=true', () => {
+  let room = null;
+
+  beforeEach(() => {
+    process.env.HUBOT_LOG_LEVEL = 'error';
+    process.env.HUBOT_HOCKEY_EXT_STANDINGS = 'true';
+    nock.disableNetConnect();
+    room = helper.createRoom();
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    delete process.env.HUBOT_LOG_LEVEL;
+    delete process.env.HUBOT_HOCKEY_EXT_STANDINGS;
+    Date.now = originalDateNow;
+    nock.cleanAll();
+    room.destroy();
+  });
+
+  it('responds with division leader standings', (done) => {
+    Date.now = () => Date.parse('Tues Nov 7 22:36:00 CST 2023');
+    nock('https://api-web.nhle.com')
+      .get('/v1/standings/2023-11-07')
+      .delay({
+        head: 100,
+        body: 200,
+      })
+      .replyWithFile(200, `${__dirname}/fixtures/api-web-nhle-standings.json`);
+
+    const selfRoom = room;
+    selfRoom.user.say('alice', '@hubot nhl');
+    setTimeout(
+      () => {
+        try {
+          expect(selfRoom.messages).to.eql([
+            ['alice', '@hubot nhl'],
+            [
+              'hubot',
+              '.----------------------------------------------------------------------.\n'
+              + '|                           Division Leaders                           |\n'
+              + '|----------------------------------------------------------------------|\n'
+              + '|         Team         | GP | W  | L | OT | PTS |  P%   |  L10  | STRK |\n'
+              + '|----------------------|----|----|---|----|-----|-------|-------|------|\n'
+              + '| Vegas Golden Knights | 13 | 11 | 1 |  1 |  23 | 0.885 | 8-1-1 | L1   |\n'
+              + '| Boston Bruins        | 12 | 10 | 1 |  1 |  21 | 0.875 | 8-1-1 | W1   |\n'
+              + '| New York Rangers     | 12 |  9 | 2 |  1 |  19 | 0.792 | 8-1-1 | W1   |\n'
+              + '| Dallas Stars         | 11 |  7 | 3 |  1 |  15 | 0.682 | 6-3-1 | L2   |\n'
+              + "'----------------------------------------------------------------------'",
+            ],
+          ]);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      },
+      500,
+    );
+  });
+});
+
+describe('hubot-hockey HUBOT_HOCKEY_HIDE_ODDS=true', () => {
+  let room = null;
+
+  beforeEach(() => {
+    process.env.HUBOT_LOG_LEVEL = 'error';
+    process.env.HUBOT_HOCKEY_HIDE_ODDS = 'true';
+    nock.disableNetConnect();
+    room = helper.createRoom();
+    nock.disableNetConnect();
+  });
+
+  afterEach(() => {
+    delete process.env.HUBOT_LOG_LEVEL;
+    delete process.env.HUBOT_HOCKEY_HIDE_ODDS;
+    Date.now = originalDateNow;
+    nock.cleanAll();
+    room.destroy();
+  });
+
+  it('responds with an in-progress game and playoff odds', (done) => {
+    Date.now = () => Date.parse('Tue Nov 7 22:42:00 CST 2023');
+    nock('https://api-web.nhle.com')
+      .get('/v1/scoreboard/nsh/now')
+      .delay({
+        head: 100,
+        body: 200,
+      })
+      .replyWithFile(200, `${__dirname}/fixtures/api-web-nhle-schedule-in-progress.json`);
+
+    nock('https://moneypuck.com')
+      .get('/moneypuck/simulations/simulations_recent.csv')
+      .replyWithFile(200, `${__dirname}/fixtures/moneypuck-simulations_recent.csv`);
+
+    const selfRoom = room;
+    selfRoom.user.say('alice', '@hubot preds');
+    setTimeout(
+      () => {
+        try {
+          expect(selfRoom.messages).to.eql([
+            ['alice', '@hubot preds'],
+            ['hubot', '11/7/2023 - Scotiabank Saddledome; TV: BSSO (A) | SNW (H)'],
+            [
+              'hubot',
+              '  Nashville Predators   2  \n'
+              + '  Calgary Flames        3  ',
+            ],
+            ['hubot', '09:04 3rd - https://www.nhl.com/gamecenter/2023020186'],
           ]);
           done();
         } catch (err) {


### PR DESCRIPTION
With `HUBOT_HOCKEY_EXT_STANDINGS` set to any truthy value, you will get additional columns in the standings table.

### Without `HUBOT_HOCKEY_EXT_STANDINGS`

```
alice>> @hubot nhl
hubot>>
.-----------------------------------------------.
|               Division Leaders                |
|-----------------------------------------------|
|         Team         | GP | W  | L | OT | PTS |
|----------------------|----|----|---|----|-----|
| Vegas Golden Knights | 13 | 11 | 1 |  1 |  23 |
| Boston Bruins        | 12 | 10 | 1 |  1 |  21 |
| New York Rangers     | 12 |  9 | 2 |  1 |  19 |
| Dallas Stars         | 11 |  7 | 3 |  1 |  15 |
'-----------------------------------------------'
```


### With `HUBOT_HOCKEY_EXT_STANDINGS`

```
alice>> @hubot nhl
hubot>>
.----------------------------------------------------------------------.
|                           Division Leaders                           |
|----------------------------------------------------------------------|
|         Team         | GP | W  | L | OT | PTS |  P%   |  L10  | STRK |
|----------------------|----|----|---|----|-----|-------|-------|------|
| Vegas Golden Knights | 13 | 11 | 1 |  1 |  23 | 0.885 | 8-1-1 | L1   |
| Boston Bruins        | 12 | 10 | 1 |  1 |  21 | 0.875 | 8-1-1 | W1   |
| New York Rangers     | 12 |  9 | 2 |  1 |  19 | 0.792 | 8-1-1 | W1   |
| Dallas Stars         | 11 |  7 | 3 |  1 |  15 | 0.682 | 6-3-1 | L2   |
'----------------------------------------------------------------------'
```

Fixes #82

---

Also adds `HUBOT_HOCKEY_HIDE_ODDS` to hide the playoff odds from MoneyPuck.